### PR TITLE
feat: 9.4 - ruby client sdk

### DIFF
--- a/_bmad-output/epic-execution-state.yaml
+++ b/_bmad-output/epic-execution-state.yaml
@@ -25,10 +25,10 @@ stories:
     dependsOn: []
   - id: "9.4"
     title: "Ruby Client SDK"
-    status: in-progress
-    currentPhase: "pr-ci"
+    status: completed
+    currentPhase: ""
     branch: "feat/9.4-ruby-client-sdk"
-    pr: null
+    pr: 37
     dependsOn: []
   - id: "9.5"
     title: "Java Client SDK"

--- a/_bmad-output/implementation-artifacts/9-4-ruby-client-sdk.md
+++ b/_bmad-output/implementation-artifacts/9-4-ruby-client-sdk.md
@@ -1,6 +1,6 @@
 # Story 9.4: Ruby Client SDK
 
-Status: review
+Status: done
 
 ## Story
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -108,7 +108,7 @@ development_status:
   9-1-go-client-sdk: done
   9-2-python-client-sdk: done
   9-3-javascript-nodejs-client-sdk: done
-  9-4-ruby-client-sdk: review
+  9-4-ruby-client-sdk: done
   9-5-java-client-sdk: backlog
   epic-9-retrospective: optional
 


### PR DESCRIPTION
## Summary

- Ruby client SDK for Fila in separate `fila-ruby` repository
- `Fila::Client` class wrapping hot-path gRPC operations (enqueue, consume, ack, nack)
- Block/Enumerator-based streaming consumer with idiomatic Ruby patterns
- Per-operation error classes: `Fila::QueueNotFoundError`, `Fila::MessageNotFoundError`, `Fila::RPCError`
- 3 integration tests (15 assertions) verifying full lifecycle with fila-server subprocess
- CI pipeline (rubocop + test), README, AGPLv3 license

## Acceptance Criteria Covered

All 13 ACs verified:
- AC1-3: Separate repo, copied protos, generated Ruby stubs via grpc_tools_ruby_protoc
- AC4-7: Client with enqueue/consume/ack/nack, ConsumeMessage with all fields
- AC8: Per-operation error hierarchy extending Fila::Error
- AC9: Keyword args, snake_case, block patterns
- AC10: Integration tests covering all 4 operations
- AC11: GitHub Actions CI
- AC12: Publishable as fila-client gem
- AC13: README with usage examples

## External Repository

SDK code: https://github.com/faiscadev/fila-ruby

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Ruby client SDK for Fila in a separate fila-ruby repo so Ruby developers can enqueue, consume, ack, and nack messages with a simple API. Updates Epic 9 tracking: Story 9.4 marked done and adds the implementation artifact.

- **New Features**
  - Fila::Client wrapper for gRPC ops: enqueue, consume, ack, nack
  - Streaming consumer via block or Enumerator; messages include id, headers, payload, fairness_key, attempt_count, queue
  - Error classes: Fila::QueueNotFoundError, Fila::MessageNotFoundError, Fila::RPCError
  - Integration-tested against fila-server; GitHub Actions CI (rubocop + tests); gem publishable with README
  - Repo: https://github.com/faiscadev/fila-ruby

<sup>Written for commit 845a73e572cd0588b96cd5c6c7516bef268e461e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

