### PR TITLE
fix: update PR description with bench results instead of posting comments

### DIFF
--- a/.github/workflows/bench-regression.yml
+++ b/.github/workflows/bench-regression.yml
@@ -127,7 +127,7 @@ jobs:
           # Get the current PR body
           current_body="$(gh pr view "$PR_NUMBER" --json body --jq '.body')"
 
-          if echo "$current_body" | grep -q '<!-- bench-results-start -->'; then
+          if echo "$current_body" | grep -qx '<!-- bench-results-start -->'; then
             # Replace existing bench results section
             echo "$current_body" | perl -0777 -pe \
               'BEGIN { local $/; open F, "/tmp/bench-section.md"; $r = <F>; chomp $r; close F }


### PR DESCRIPTION
## Summary
- Bench-regression workflow now updates the PR description instead of posting comments
- Uses HTML comment markers to delimit the benchmark section
- On first run, appends results to the PR body; on subsequent runs, replaces the existing section
- Uses `--body-file` for safe handling of PR bodies with special characters

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- bench-results-start -->
## Benchmark Results (median of 3 runs)

**Commit:** `1a6b809`  
**Time:** 2026-03-19T01:58:38Z

| Benchmark | Value | Unit |
|---|---:|---|
| compaction_active_p99 | 0.487334 | ms |
| compaction_idle_p99 | 0.483539 | ms |
| compaction_p99_delta | 0.015385000000000038 | ms |
| consumer_concurrency_100_throughput | 1768.3333333333333 | msg/s |
| consumer_concurrency_10_throughput | 1938.6666666666667 | msg/s |
| consumer_concurrency_1_throughput | 334.3333333333333 | msg/s |
| e2e_latency_p50_light | 0.408616 | ms |
| e2e_latency_p95_light | 0.463794 | ms |
| e2e_latency_p99_light | 0.5480889999999999 | ms |
| enqueue_throughput_1kb | 2627.584206943223 | msg/s |
| enqueue_throughput_1kb_mbps | 2.566000202092991 | MB/s |
| fairness_accuracy_max_deviation | 0.1999999999999988 | % deviation |
| fairness_accuracy_tenant-1 | 0.1999999999999988 | % deviation |
| fairness_accuracy_tenant-2 | 0.1999999999999988 | % deviation |
| fairness_accuracy_tenant-3 | 0.099999999999989 | % deviation |
| fairness_accuracy_tenant-4 | 0.099999999999989 | % deviation |
| fairness_accuracy_tenant-5 | 0.099999999999989 | % deviation |
| fairness_overhead_fair_throughput | 1398.9872752780732 | msg/s |
| fairness_overhead_fifo_throughput | 1435.4434059334872 | msg/s |
| fairness_overhead_pct | 2.539712154775342 | % |
| key_cardinality_10_throughput | 2403.392789643585 | msg/s |
| key_cardinality_10k_throughput | 596.255440708829 | msg/s |
| key_cardinality_1k_throughput | 1124.2313089673007 | msg/s |
| lua_on_enqueue_overhead_us | 21.357798330686137 | us |
| lua_throughput_with_hook | 1165.383610526118 | msg/s |
| memory_per_message_overhead | 3006.464 | bytes/msg |
| memory_rss_idle | 166.53515625 | MB |
| memory_rss_loaded_10k | 195.1796875 | MB |
<!-- bench-results-end -->
