### PR TITLE
fix: suppress result_large_err clippy warning in cluster store

### DIFF
--- a/crates/fila-core/src/cluster/store.rs
+++ b/crates/fila-core/src/cluster/store.rs
@@ -591,7 +591,7 @@ impl FilaRaftStore {
     ///
     /// Returns `Err` if a storage mutation fails — the caller should propagate
     /// this as a `StorageError` so Raft can handle the failure appropriately.
-    #[allow(clippy::result_large_err)] // StorageError<NodeId> is an openraft type we can't shrink; boxing it would require unboxing at the call site since apply_to_state_machine returns the same type
+    #[allow(clippy::result_large_err)] // StorageError<NodeId> is an openraft type we can't shrink; the caller apply_to_state_machine is an openraft trait method with a fixed signature — we cannot change its return type
     fn apply_to_broker_storage(
         &self,
         storage: &dyn StorageEngine,


### PR DESCRIPTION
## Summary
- Adds `#[allow(clippy::result_large_err)]` to `apply_to_broker_storage` in `crates/fila-core/src/cluster/store.rs`
- `StorageError<NodeId>` is an openraft type we can't shrink; boxing it would require explicit unboxing at the call site since `apply_to_state_machine` returns the same error type — adding noise for no benefit
- Attribute comment documents the reasoning inline

## Test plan
- [ ] `cargo clippy -p fila-core` produces zero warnings
- [ ] All existing tests pass

Closes #61

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress `clippy::result_large_err` in `apply_to_broker_storage` to keep builds clean without unnecessary boxing. `StorageError<NodeId>` is an `openraft` type and `apply_to_state_machine` has a fixed `openraft` trait signature returning it, so we document this inline and allow the lint.

<sup>Written for commit d5b10794ae4e68955f34fcedf8395bd411a79781. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

