### PR TITLE
feat: broker-managed consumer groups (story 18.1)

### DIFF
--- a/_bmad-output/implementation-artifacts/epic-execution-state.yaml
+++ b/_bmad-output/implementation-artifacts/epic-execution-state.yaml
@@ -1,31 +1,17 @@
-epic: "Epic 17: Cluster Hardening"
+epic: "Epic 18: Consumer Groups"
 baseBranch: main
-startedAt: "2026-03-21"
+startedAt: "2026-03-22"
 stories:
-  - id: "17.1"
-    title: "Cluster Error Clarity & Ack/Nack Performance"
-    status: completed
-    currentPhase: ""
-    branch: "feat/17.1-cluster-error-clarity-ack-nack-performance"
-    pr: 82
+  - id: "18.1"
+    title: "Broker-Managed Consumer Groups"
+    status: in-progress
+    currentPhase: "implementation"
+    branch: "feat/18.1-broker-managed-consumer-groups"
+    pr: null
     dependsOn: []
-  - id: "17.2"
-    title: "Consume Leader Hint & SDK Reconnect"
-    status: completed
-    currentPhase: ""
-    branch: "feat/17.2-consume-leader-hint-sdk-reconnect"
-    pr: 83
-    dependsOn: ["17.1"]
-  - id: "17.3"
-    title: "Automatic Queue-to-Node Assignment"
-    status: completed
-    currentPhase: ""
-    branch: "feat/17.3-automatic-queue-to-node-assignment"
-    pr: 84
-    dependsOn: []
-completedAt: "2026-03-22"
+completedAt: null
 summary:
-  total: 3
-  completed: 3
+  total: 1
+  completed: 0
   skipped: 0
 skippedIssues: []

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -186,8 +186,8 @@ development_status:
   epic-17-retrospective: done
 
   # Epic 18: Consumer Groups
-  epic-18: backlog
-  18-1-broker-managed-consumer-groups: backlog
+  epic-18: in-progress
+  18-1-broker-managed-consumer-groups: in-progress
   epic-18-retrospective: optional
 
   # Epic 19: Developer Experience (docs website, Helm, Lua helpers, guides)

--- a/_bmad-output/implementation-artifacts/stories/18-1-broker-managed-consumer-groups.md
+++ b/_bmad-output/implementation-artifacts/stories/18-1-broker-managed-consumer-groups.md
@@ -1,0 +1,76 @@
+# Story 18.1: Broker-Managed Consumer Groups
+
+Status: in-progress
+
+## Story
+
+As a developer building multi-instance consumer services,
+I want to specify a consumer group when consuming messages,
+so that the broker distributes messages across group members (each message to exactly one member) without requiring external coordination.
+
+## Acceptance Criteria
+
+1. **Given** a consumer calls Consume with `consumer_group = "my-group"` **Then** it joins the named group for that queue.
+2. **Given** 3 consumers in the same group consuming from a queue with 9 messages **Then** each consumer receives ~3 messages (round-robin within group).
+3. **Given** the broker tracks group membership **Then** it knows which consumers belong to which group for which queue.
+4. **Given** messages are distributed across group members **Then** each message goes to exactly one member — no duplicates.
+5. **Given** DRR fair scheduling selects a message for delivery **Then** if the target is a group, one member receives it via round-robin. Groups receive fairly-scheduled messages, then round-robin within group.
+6. **Given** a consumer joins or leaves a group **Then** rebalancing happens automatically — remaining members absorb the departed member's share.
+7. **Given** in-flight messages when a consumer disconnects **Then** they are governed by visibility timeout (existing mechanism) — no message loss.
+8. **Given** a consumer calls Consume without `consumer_group` (empty string) **Then** it operates independently, same as before (backward compatible).
+9. **Given** cluster mode with Raft-per-queue **Then** consumer groups work because consumers connect to the leader node, and group state is in the scheduler (leader-local).
+10. **Given** an operator calls `GetConsumerGroups` admin RPC **Then** they see all active groups with queue, group name, member count, and member IDs.
+11. **Given** mixed consumers (some in groups, some independent) on the same queue **Then** the group counts as one delivery target and the independent consumer as another, with round-robin across targets.
+
+## Tasks / Subtasks
+
+- [x] Task 1: Proto changes (backward compatible)
+  - [x] 1.1: Add `string consumer_group = 2` to `ConsumeRequest` in service.proto
+  - [x] 1.2: Add `GetConsumerGroups` RPC to admin.proto with request/response messages
+  - [x] 1.3: Add `ConsumerGroupInfo`, `ConsumerGroupMember` proto messages
+
+- [x] Task 2: Core consumer group manager
+  - [x] 2.1: Create `ConsumerGroupManager` in `scheduler/consumer_groups.rs`
+  - [x] 2.2: Implement join/leave/next_member/group_members/all_groups/remove_queue
+  - [x] 2.3: Unit tests for group manager (5 tests)
+
+- [x] Task 3: Scheduler integration
+  - [x] 3.1: Add `consumer_group: Option<String>` to `ConsumerEntry` and `RegisterConsumer` command
+  - [x] 3.2: Add `GetConsumerGroups` command variant to `SchedulerCommand`
+  - [x] 3.3: Add `ConsumerGroupsError` per-command error type
+  - [x] 3.4: Wire consumer group join/leave in handle_command for Register/Unregister
+  - [x] 3.5: Wire GetConsumerGroups command handler
+  - [x] 3.6: Clean up consumer groups on `drop_queue_consumers` (leader loss)
+
+- [x] Task 4: Delivery logic changes
+  - [x] 4.1: Refactor `try_deliver_to_consumer` to use delivery targets (Independent / Group)
+  - [x] 4.2: Group target resolves to one member via ConsumerGroupManager.next_member()
+  - [x] 4.3: Fallback to next group member if channel full/closed
+  - [x] 4.4: Independent consumers work exactly as before
+
+- [x] Task 5: gRPC service layer
+  - [x] 5.1: Pass `consumer_group` from `ConsumeRequest` to `RegisterConsumer` command in service.rs
+  - [x] 5.2: Implement `GetConsumerGroups` handler in admin_service.rs
+  - [x] 5.3: Add `IntoStatus` for `ConsumerGroupsError` in error.rs
+
+- [x] Task 6: SDK update
+  - [x] 6.1: Add `consume_group(queue, group)` method to Rust SDK client
+  - [x] 6.2: Existing `consume(queue)` unchanged (backward compatible)
+
+- [x] Task 7: Integration tests (7 tests)
+  - [x] 7.1: 3 consumers in group each get ~33% of 9 messages
+  - [x] 7.2: Consumer leaves group, remaining 2 get ~50% each
+  - [x] 7.3: No consumer group = independent (backward compat)
+  - [x] 7.4: Mixed group + independent consumers
+  - [x] 7.5: GetConsumerGroups returns correct info
+  - [x] 7.6: Single-member group gets all messages
+  - [x] 7.7: Multiple groups on same queue
+
+- [x] Task 8: Update all existing RegisterConsumer call sites with `consumer_group: None`
+
+## Technical Notes
+
+- Consumer groups are a scheduler-local concept (in-memory). No Raft replication needed since consumers always connect to the Raft leader for their queue.
+- The `ConsumerGroupManager` tracks (queue_id, group_name) -> members with per-group round-robin state.
+- Delivery targets: each group counts as one target, each independent consumer counts as one target. Round-robin across targets. Within a group, internal round-robin.
+- Session timeout for disconnected consumers handled by existing `UnregisterConsumer` on stream close + visibility timeout for in-flight messages.

--- a/crates/fila-core/src/broker/command.rs
+++ b/crates/fila-core/src/broker/command.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use uuid::Uuid;
 
 use crate::error::{
-    AckError, ConfigError, CreateQueueError, DeleteQueueError, EnqueueError, ListQueuesError,
-    NackError, RedriveError, StatsError,
+    AckError, ConfigError, ConsumerGroupsError, CreateQueueError, DeleteQueueError, EnqueueError,
+    ListQueuesError, NackError, RedriveError, StatsError,
 };
 
 /// A message ready for delivery to a consumer.
@@ -31,6 +31,15 @@ pub struct QueueSummary {
     pub leader_node_id: u64,
 }
 
+/// Summary info for a consumer group, returned by GetConsumerGroups.
+#[derive(Debug, Clone)]
+pub struct ConsumerGroupInfo {
+    pub queue: String,
+    pub group_name: String,
+    pub member_count: u32,
+    pub members: Vec<String>,
+}
+
 /// Commands sent from IO threads to the single-threaded scheduler core.
 ///
 /// Each variant that expects a response includes a `tokio::sync::oneshot::Sender`
@@ -54,6 +63,9 @@ pub enum SchedulerCommand {
     RegisterConsumer {
         queue_id: String,
         consumer_id: String,
+        /// Optional consumer group name. When set, this consumer joins the
+        /// named group and messages are distributed across group members.
+        consumer_group: Option<String>,
         tx: tokio::sync::mpsc::Sender<ReadyMessage>,
     },
     UnregisterConsumer {
@@ -100,6 +112,10 @@ pub enum SchedulerCommand {
     },
     ListQueues {
         reply: tokio::sync::oneshot::Sender<Result<Vec<QueueSummary>, ListQueuesError>>,
+    },
+    GetConsumerGroups {
+        queue_filter: Option<String>,
+        reply: tokio::sync::oneshot::Sender<Result<Vec<ConsumerGroupInfo>, ConsumerGroupsError>>,
     },
     /// Rebuild in-memory scheduler state (DRR keys, pending index) for a
     /// single queue. Used when this node becomes the Raft leader for a queue

--- a/crates/fila-core/src/broker/mod.rs
+++ b/crates/fila-core/src/broker/mod.rs
@@ -16,7 +16,7 @@ use tracing::info;
 use crate::error::{BrokerError, BrokerResult};
 use crate::storage::StorageEngine;
 
-pub use command::{QueueSummary, ReadyMessage, SchedulerCommand};
+pub use command::{ConsumerGroupInfo, QueueSummary, ReadyMessage, SchedulerCommand};
 pub use config::{AuthConfig, BrokerConfig, TlsParams};
 
 use scheduler::Scheduler;

--- a/crates/fila-core/src/broker/scheduler/consumer_groups.rs
+++ b/crates/fila-core/src/broker/scheduler/consumer_groups.rs
@@ -1,0 +1,208 @@
+use std::collections::HashMap;
+
+/// Key for a consumer group: (queue_id, group_name).
+type GroupKey = (String, String);
+
+/// Tracks membership and round-robin state for a single consumer group.
+struct GroupState {
+    /// Ordered list of consumer IDs in this group. The order determines
+    /// round-robin delivery. New members are appended at the end.
+    members: Vec<String>,
+    /// Round-robin index for this group. Points to the next member that
+    /// should receive a message.
+    rr_idx: usize,
+}
+
+/// Manages consumer group membership and per-group round-robin delivery.
+///
+/// A consumer group allows multiple consumers to share message delivery
+/// for a queue: each message goes to exactly one member of the group.
+/// Consumers without a group operate independently (classic behavior).
+pub(super) struct ConsumerGroupManager {
+    /// Map from (queue_id, group_name) to the group's state.
+    groups: HashMap<GroupKey, GroupState>,
+    /// Reverse index: consumer_id → (queue_id, group_name) for O(1) removal.
+    consumer_to_group: HashMap<String, GroupKey>,
+}
+
+impl ConsumerGroupManager {
+    pub(super) fn new() -> Self {
+        Self {
+            groups: HashMap::new(),
+            consumer_to_group: HashMap::new(),
+        }
+    }
+
+    /// Add a consumer to a group. If the group doesn't exist, it is created.
+    pub(super) fn join(&mut self, queue_id: &str, group_name: &str, consumer_id: &str) {
+        let key = (queue_id.to_string(), group_name.to_string());
+        self.consumer_to_group
+            .insert(consumer_id.to_string(), key.clone());
+        let state = self.groups.entry(key).or_insert_with(|| GroupState {
+            members: Vec::new(),
+            rr_idx: 0,
+        });
+        // Avoid duplicate membership (idempotent join)
+        if !state.members.contains(&consumer_id.to_string()) {
+            state.members.push(consumer_id.to_string());
+        }
+    }
+
+    /// Remove a consumer from its group. If the group becomes empty, it is removed.
+    /// Returns the (queue_id, group_name) if the consumer was in a group.
+    pub(super) fn leave(&mut self, consumer_id: &str) -> Option<GroupKey> {
+        let key = self.consumer_to_group.remove(consumer_id)?;
+        if let Some(state) = self.groups.get_mut(&key) {
+            state.members.retain(|id| id != consumer_id);
+            // Adjust rr_idx if it's past the end
+            if !state.members.is_empty() {
+                state.rr_idx %= state.members.len();
+            }
+            if state.members.is_empty() {
+                self.groups.remove(&key);
+            }
+        }
+        Some(key)
+    }
+
+    /// Check if a consumer is in a group.
+    pub(super) fn is_in_group(&self, consumer_id: &str) -> bool {
+        self.consumer_to_group.contains_key(consumer_id)
+    }
+
+    /// Get all groups, optionally filtered by queue.
+    pub(super) fn all_groups(
+        &self,
+        queue_filter: Option<&str>,
+    ) -> Vec<crate::broker::command::ConsumerGroupInfo> {
+        self.groups
+            .iter()
+            .filter(|((qid, _), _)| queue_filter.map_or(true, |filter| qid == filter))
+            .map(
+                |((qid, name), state)| crate::broker::command::ConsumerGroupInfo {
+                    queue: qid.clone(),
+                    group_name: name.clone(),
+                    member_count: state.members.len() as u32,
+                    members: state.members.clone(),
+                },
+            )
+            .collect()
+    }
+
+    /// Pick the next consumer in the group via round-robin.
+    /// Returns `None` if the group has no members.
+    pub(super) fn next_member(&mut self, queue_id: &str, group_name: &str) -> Option<String> {
+        let key = (queue_id.to_string(), group_name.to_string());
+        let state = self.groups.get_mut(&key)?;
+        if state.members.is_empty() {
+            return None;
+        }
+        let idx = state.rr_idx % state.members.len();
+        let consumer_id = state.members[idx].clone();
+        state.rr_idx = idx.wrapping_add(1);
+        Some(consumer_id)
+    }
+
+    /// Get the list of member consumer IDs for a group.
+    pub(super) fn group_members(&self, queue_id: &str, group_name: &str) -> Option<&[String]> {
+        let key = (queue_id.to_string(), group_name.to_string());
+        self.groups.get(&key).map(|s| s.members.as_slice())
+    }
+
+    /// Remove all consumers for a queue (used on leader loss / drop_queue_consumers).
+    pub(super) fn remove_queue(&mut self, queue_id: &str) {
+        let keys_to_remove: Vec<GroupKey> = self
+            .groups
+            .keys()
+            .filter(|(qid, _)| qid == queue_id)
+            .cloned()
+            .collect();
+        for key in keys_to_remove {
+            if let Some(state) = self.groups.remove(&key) {
+                for consumer_id in &state.members {
+                    self.consumer_to_group.remove(consumer_id);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn join_and_leave() {
+        let mut mgr = ConsumerGroupManager::new();
+        mgr.join("q1", "grp1", "c1");
+        mgr.join("q1", "grp1", "c2");
+        assert!(mgr.is_in_group("c1"));
+        assert!(mgr.is_in_group("c2"));
+        assert!(!mgr.is_in_group("c3"));
+
+        assert_eq!(mgr.group_members("q1", "grp1").unwrap().len(), 2);
+
+        // Leave
+        let key = mgr.leave("c1");
+        assert_eq!(key, Some(("q1".to_string(), "grp1".to_string())));
+        assert!(!mgr.is_in_group("c1"));
+        assert_eq!(mgr.group_members("q1", "grp1").unwrap().len(), 1);
+
+        // Leave last member removes group
+        mgr.leave("c2");
+        assert!(mgr.group_members("q1", "grp1").is_none());
+    }
+
+    #[test]
+    fn round_robin_distribution() {
+        let mut mgr = ConsumerGroupManager::new();
+        mgr.join("q1", "grp1", "c1");
+        mgr.join("q1", "grp1", "c2");
+        mgr.join("q1", "grp1", "c3");
+
+        let m1 = mgr.next_member("q1", "grp1").unwrap();
+        let m2 = mgr.next_member("q1", "grp1").unwrap();
+        let m3 = mgr.next_member("q1", "grp1").unwrap();
+        let m4 = mgr.next_member("q1", "grp1").unwrap();
+
+        assert_eq!(m1, "c1");
+        assert_eq!(m2, "c2");
+        assert_eq!(m3, "c3");
+        assert_eq!(m4, "c1"); // wraps around
+    }
+
+    #[test]
+    fn idempotent_join() {
+        let mut mgr = ConsumerGroupManager::new();
+        mgr.join("q1", "grp1", "c1");
+        mgr.join("q1", "grp1", "c1"); // duplicate
+        assert_eq!(mgr.group_members("q1", "grp1").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn remove_queue_clears_all_groups() {
+        let mut mgr = ConsumerGroupManager::new();
+        mgr.join("q1", "grp1", "c1");
+        mgr.join("q1", "grp2", "c2");
+        mgr.join("q2", "grp1", "c3");
+
+        mgr.remove_queue("q1");
+        assert!(!mgr.is_in_group("c1"));
+        assert!(!mgr.is_in_group("c2"));
+        assert!(mgr.is_in_group("c3")); // q2 untouched
+    }
+
+    #[test]
+    fn all_groups_with_filter() {
+        let mut mgr = ConsumerGroupManager::new();
+        mgr.join("q1", "grp1", "c1");
+        mgr.join("q2", "grp2", "c2");
+
+        let all = mgr.all_groups(None);
+        assert_eq!(all.len(), 2);
+
+        let q1_only = mgr.all_groups(Some("q1"));
+        assert_eq!(q1_only.len(), 1);
+        assert_eq!(q1_only[0].queue, "q1");
+    }
+}

--- a/crates/fila-core/src/broker/scheduler/delivery.rs
+++ b/crates/fila-core/src/broker/scheduler/delivery.rs
@@ -192,6 +192,14 @@ impl Scheduler {
     }
 
     /// Attempt to deliver a single message to a consumer via round-robin.
+    ///
+    /// Delivery targets are built from the queue's consumers:
+    /// - Each consumer group counts as one target (internal round-robin picks a member)
+    /// - Each independent (non-group) consumer counts as one target
+    ///
+    /// Round-robin rotates across targets. Within a group, the ConsumerGroupManager
+    /// handles its own round-robin to pick the specific member.
+    ///
     /// Returns true if delivery succeeded.
     fn try_deliver_to_consumer(
         &mut self,
@@ -200,94 +208,172 @@ impl Scheduler {
         lease_key: &[u8],
         visibility_timeout_ms: u64,
     ) -> bool {
-        let queue_consumers: Vec<(String, usize)> = self
-            .consumers
-            .iter()
-            .enumerate()
-            .filter(|(_, (_, e))| e.queue_id == queue_id)
-            .map(|(i, (cid, _))| (cid.clone(), i))
-            .collect();
+        // Build delivery targets: independent consumers + one entry per group.
+        // A "target" is either Target::Independent(consumer_id) or Target::Group(group_name).
+        let mut targets: Vec<DeliveryTarget> = Vec::new();
+        let mut seen_groups: HashSet<String> = HashSet::new();
 
-        if queue_consumers.is_empty() {
+        for (cid, entry) in &self.consumers {
+            if entry.queue_id != queue_id {
+                continue;
+            }
+            if let Some(ref group) = entry.consumer_group {
+                if seen_groups.insert(group.clone()) {
+                    targets.push(DeliveryTarget::Group(group.clone()));
+                }
+            } else {
+                targets.push(DeliveryTarget::Independent(cid.clone()));
+            }
+        }
+
+        if targets.is_empty() {
             return false;
         }
 
-        let rr_idx = self
+        let mut rr_idx = *self
             .consumer_rr_idx
             .entry(queue_id.to_string())
             .or_insert(0);
         let mut attempts = 0;
 
-        while attempts < queue_consumers.len() {
-            let (ref cid, _) = queue_consumers[*rr_idx % queue_consumers.len()];
-            *rr_idx = rr_idx.wrapping_add(1);
+        while attempts < targets.len() {
+            let target = targets[rr_idx % targets.len()].clone();
+            rr_idx = rr_idx.wrapping_add(1);
             attempts += 1;
 
-            let now_ns = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos() as u64;
-            let expiry_ns = now_ns + visibility_timeout_ms * 1_000_000;
-
-            let lease_val = crate::storage::keys::lease_value(cid, expiry_ns);
-            let expiry_key = crate::storage::keys::lease_expiry_key(expiry_ns, queue_id, &msg.id);
-
-            if let Err(e) = self.storage.apply_mutations(vec![
-                Mutation::PutLease {
-                    key: lease_key.to_vec(),
-                    value: lease_val,
-                },
-                Mutation::PutLeaseExpiry {
-                    key: expiry_key.clone(),
-                },
-            ]) {
-                error!(msg_id = %msg.id, error = %e, "failed to write lease");
-                return false;
-            }
-
-            let ready = ReadyMessage {
-                msg_id: msg.id,
-                queue_id: msg.queue_id.clone(),
-                headers: msg.headers.clone(),
-                payload: msg.payload.clone(),
-                fairness_key: msg.fairness_key.clone(),
-                weight: msg.weight,
-                throttle_keys: msg.throttle_keys.clone(),
-                attempt_count: msg.attempt_count,
-            };
-
-            // Look up the consumer's tx channel
-            let Some(entry) = self.consumers.get(cid) else {
-                continue;
-            };
-
-            match entry.tx.try_send(ready) {
-                Ok(()) => return true,
-                Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                    warn!(%cid, msg_id = %msg.id, "consumer channel full, trying next");
-                    if let Err(e) = self.storage.apply_mutations(vec![
-                        Mutation::DeleteLease {
-                            key: lease_key.to_vec(),
-                        },
-                        Mutation::DeleteLeaseExpiry { key: expiry_key },
-                    ]) {
-                        error!(%cid, msg_id = %msg.id, error = %e, "failed to roll back lease");
+            match &target {
+                DeliveryTarget::Independent(cid) => {
+                    if let Some(true) = self.try_send_to_consumer(
+                        cid,
+                        queue_id,
+                        msg,
+                        lease_key,
+                        visibility_timeout_ms,
+                    ) {
+                        self.consumer_rr_idx.insert(queue_id.to_string(), rr_idx);
+                        return true;
                     }
                 }
-                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                    warn!(%cid, msg_id = %msg.id, "consumer channel closed, trying next");
-                    if let Err(e) = self.storage.apply_mutations(vec![
-                        Mutation::DeleteLease {
-                            key: lease_key.to_vec(),
-                        },
-                        Mutation::DeleteLeaseExpiry { key: expiry_key },
-                    ]) {
-                        error!(%cid, msg_id = %msg.id, error = %e, "failed to roll back lease");
+                DeliveryTarget::Group(group_name) => {
+                    // Try each group member in round-robin order.
+                    // next_member() advances the group's internal RR on each call.
+                    let member_count = self
+                        .consumer_groups
+                        .group_members(queue_id, group_name)
+                        .map_or(0, |m| m.len());
+                    let mut group_attempts = 0;
+                    while group_attempts < member_count {
+                        let Some(cid) = self.consumer_groups.next_member(queue_id, group_name)
+                        else {
+                            break;
+                        };
+                        group_attempts += 1;
+                        if let Some(true) = self.try_send_to_consumer(
+                            &cid,
+                            queue_id,
+                            msg,
+                            lease_key,
+                            visibility_timeout_ms,
+                        ) {
+                            self.consumer_rr_idx.insert(queue_id.to_string(), rr_idx);
+                            return true;
+                        }
                     }
                 }
             }
         }
 
+        // Write back the rr index even on failure
+        self.consumer_rr_idx.insert(queue_id.to_string(), rr_idx);
         false
     }
+
+    /// Attempt to send a message to a specific consumer. Returns:
+    /// - `Some(true)` if delivery succeeded
+    /// - `Some(false)` if the consumer was full/closed (lease rolled back)
+    /// - `None` if the consumer was not found
+    fn try_send_to_consumer(
+        &mut self,
+        cid: &str,
+        queue_id: &str,
+        msg: &crate::message::Message,
+        lease_key: &[u8],
+        visibility_timeout_ms: u64,
+    ) -> Option<bool> {
+        // Verify consumer exists
+        if !self.consumers.contains_key(cid) {
+            return None;
+        }
+
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+        let expiry_ns = now_ns + visibility_timeout_ms * 1_000_000;
+
+        let lease_val = crate::storage::keys::lease_value(cid, expiry_ns);
+        let expiry_key = crate::storage::keys::lease_expiry_key(expiry_ns, queue_id, &msg.id);
+
+        if let Err(e) = self.storage.apply_mutations(vec![
+            Mutation::PutLease {
+                key: lease_key.to_vec(),
+                value: lease_val,
+            },
+            Mutation::PutLeaseExpiry {
+                key: expiry_key.clone(),
+            },
+        ]) {
+            error!(msg_id = %msg.id, error = %e, "failed to write lease");
+            return Some(false);
+        }
+
+        let ready = ReadyMessage {
+            msg_id: msg.id,
+            queue_id: msg.queue_id.clone(),
+            headers: msg.headers.clone(),
+            payload: msg.payload.clone(),
+            fairness_key: msg.fairness_key.clone(),
+            weight: msg.weight,
+            throttle_keys: msg.throttle_keys.clone(),
+            attempt_count: msg.attempt_count,
+        };
+
+        // Look up the consumer's tx channel
+        let entry = self.consumers.get(cid)?;
+
+        match entry.tx.try_send(ready) {
+            Ok(()) => Some(true),
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                warn!(%cid, msg_id = %msg.id, "consumer channel full, trying next");
+                if let Err(e) = self.storage.apply_mutations(vec![
+                    Mutation::DeleteLease {
+                        key: lease_key.to_vec(),
+                    },
+                    Mutation::DeleteLeaseExpiry { key: expiry_key },
+                ]) {
+                    error!(%cid, msg_id = %msg.id, error = %e, "failed to roll back lease");
+                }
+                Some(false)
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                warn!(%cid, msg_id = %msg.id, "consumer channel closed, trying next");
+                if let Err(e) = self.storage.apply_mutations(vec![
+                    Mutation::DeleteLease {
+                        key: lease_key.to_vec(),
+                    },
+                    Mutation::DeleteLeaseExpiry { key: expiry_key },
+                ]) {
+                    error!(%cid, msg_id = %msg.id, error = %e, "failed to roll back lease");
+                }
+                Some(false)
+            }
+        }
+    }
+}
+
+/// A delivery target: either an independent consumer or a consumer group.
+#[derive(Clone)]
+enum DeliveryTarget {
+    Independent(String),
+    Group(String),
 }

--- a/crates/fila-core/src/broker/scheduler/mod.rs
+++ b/crates/fila-core/src/broker/scheduler/mod.rs
@@ -15,14 +15,19 @@ use crate::lua::LuaEngine;
 use crate::storage::{Mutation, StorageEngine};
 
 mod admin_handlers;
+mod consumer_groups;
 mod delivery;
 mod handlers;
 mod metrics_recording;
 mod recovery;
 
+use consumer_groups::ConsumerGroupManager;
+
 /// A registered consumer waiting for messages.
 pub(super) struct ConsumerEntry {
     pub(super) queue_id: String,
+    /// Optional consumer group this consumer belongs to.
+    pub(super) consumer_group: Option<String>,
     pub(super) tx: tokio::sync::mpsc::Sender<ReadyMessage>,
 }
 
@@ -69,6 +74,8 @@ pub struct Scheduler {
     /// Per-(queue_id, fairness_key) delivery counts for fair share ratio calculation.
     /// Reset each time record_gauges() is called.
     fairness_deliveries: HashMap<(String, String), u64>,
+    /// Consumer group manager: tracks group membership and round-robin state.
+    consumer_groups: ConsumerGroupManager,
 }
 
 impl Scheduler {
@@ -108,6 +115,7 @@ impl Scheduler {
                 Metrics::new()
             },
             fairness_deliveries: HashMap::new(),
+            consumer_groups: ConsumerGroupManager::new(),
         }
     }
 
@@ -203,13 +211,20 @@ impl Scheduler {
             SchedulerCommand::RegisterConsumer {
                 queue_id,
                 consumer_id,
+                consumer_group,
                 tx,
             } => {
-                info!(%queue_id, %consumer_id, "consumer registered");
+                if let Some(ref group) = consumer_group {
+                    info!(%queue_id, %consumer_id, %group, "consumer registered (group)");
+                    self.consumer_groups.join(&queue_id, group, &consumer_id);
+                } else {
+                    info!(%queue_id, %consumer_id, "consumer registered");
+                }
                 self.consumers.insert(
                     consumer_id,
                     ConsumerEntry {
                         queue_id: queue_id.clone(),
+                        consumer_group,
                         tx,
                     },
                 );
@@ -217,7 +232,12 @@ impl Scheduler {
                 self.drr_deliver_queue(&queue_id);
             }
             SchedulerCommand::UnregisterConsumer { consumer_id } => {
-                info!(%consumer_id, "consumer unregistered");
+                if self.consumer_groups.is_in_group(&consumer_id) {
+                    info!(%consumer_id, "consumer unregistered (group member)");
+                    self.consumer_groups.leave(&consumer_id);
+                } else {
+                    info!(%consumer_id, "consumer unregistered");
+                }
                 self.consumers.remove(&consumer_id);
             }
             SchedulerCommand::CreateQueue {
@@ -273,6 +293,13 @@ impl Scheduler {
             SchedulerCommand::ListQueues { reply } => {
                 let result = self.handle_list_queues();
                 let _ = reply.send(result);
+            }
+            SchedulerCommand::GetConsumerGroups {
+                queue_filter,
+                reply,
+            } => {
+                let groups = self.consumer_groups.all_groups(queue_filter.as_deref());
+                let _ = reply.send(Ok(groups));
             }
             SchedulerCommand::RecoverQueue { queue_id, reply } => {
                 info!(%queue_id, "recover queue command received (leader promotion)");

--- a/crates/fila-core/src/broker/scheduler/recovery.rs
+++ b/crates/fila-core/src/broker/scheduler/recovery.rs
@@ -379,6 +379,7 @@ impl Scheduler {
         self.consumers.retain(|_, entry| entry.queue_id != queue_id);
         let dropped = before - self.consumers.len();
         if dropped > 0 {
+            self.consumer_groups.remove_queue(queue_id);
             info!(queue_id, dropped, "dropped consumer streams (leader loss)");
         }
     }

--- a/crates/fila-core/src/broker/scheduler/tests/ack_nack.rs
+++ b/crates/fila-core/src/broker/scheduler/tests/ack_nack.rs
@@ -11,6 +11,7 @@ fn ack_removes_message_lease_and_expiry() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "ack-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -94,6 +95,7 @@ fn ack_same_message_twice_returns_not_found() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "double-ack-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -154,6 +156,7 @@ fn nack_requeues_message_with_incremented_attempt_count() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "nack-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -219,6 +222,7 @@ fn nack_removes_lease_and_lease_expiry() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "nack-lease-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -310,6 +314,7 @@ fn double_nack_returns_not_found() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "double-nack-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -376,6 +381,7 @@ fn nack_then_ack_completes_message_lifecycle() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "nack-ack-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -453,6 +459,7 @@ fn lease_expiry_redelivers_message_with_incremented_attempt_count() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "expiry-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -518,6 +525,7 @@ fn lease_expiry_clears_lease_and_expiry_entries() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "expiry-clean-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -607,6 +615,7 @@ fn lease_expiry_multiple_messages_different_timeouts() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "fast-queue".to_string(),
         consumer_id: "c-fast".to_string(),
+        consumer_group: None,
         tx: consumer_tx_fast,
     })
     .unwrap();
@@ -615,6 +624,7 @@ fn lease_expiry_multiple_messages_different_timeouts() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "slow-queue".to_string(),
         consumer_id: "c-slow".to_string(),
+        consumer_group: None,
         tx: consumer_tx_slow,
     })
     .unwrap();
@@ -692,6 +702,7 @@ fn ack_before_expiry_prevents_redelivery() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "ack-before-expiry-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();

--- a/crates/fila-core/src/broker/scheduler/tests/common.rs
+++ b/crates/fila-core/src/broker/scheduler/tests/common.rs
@@ -214,6 +214,7 @@ pub(super) fn dlq_one_message(
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: queue_name.to_string(),
         consumer_id: format!("dlq-helper-{msg_id}"),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();

--- a/crates/fila-core/src/broker/scheduler/tests/config.rs
+++ b/crates/fila-core/src/broker/scheduler/tests/config.rs
@@ -233,6 +233,7 @@ fn set_config_throttle_rate_enforced_on_delivery() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "config-throttle-q".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -473,6 +474,7 @@ fn lua_e2e_non_throttle_config_via_set_config() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "lua-config-e2e".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();

--- a/crates/fila-core/src/broker/scheduler/tests/consumer_groups.rs
+++ b/crates/fila-core/src/broker/scheduler/tests/consumer_groups.rs
@@ -1,0 +1,503 @@
+use super::*;
+
+#[test]
+fn consumer_group_distributes_messages_round_robin() {
+    let (tx, mut scheduler, _dir) = test_setup();
+
+    send_create_queue(&tx, "cg-queue");
+
+    // Register 3 consumers in the same group
+    let (c1_tx, mut c1_rx) = tokio::sync::mpsc::channel(64);
+    tx.send(SchedulerCommand::RegisterConsumer {
+        queue_id: "cg-queue".to_string(),
+        consumer_id: "c1".to_string(),
+        consumer_group: Some("group-a".to_string()),
+        tx: c1_tx,
+    })
+    .unwrap();
+
+    let (c2_tx, mut c2_rx) = tokio::sync::mpsc::channel(64);
+    tx.send(SchedulerCommand::RegisterConsumer {
+        queue_id: "cg-queue".to_string(),
+        consumer_id: "c2".to_string(),
+        consumer_group: Some("group-a".to_string()),
+        tx: c2_tx,
+    })
+    .unwrap();
+
+    let (c3_tx, mut c3_rx) = tokio::sync::mpsc::channel(64);
+    tx.send(SchedulerCommand::RegisterConsumer {
+        queue_id: "cg-queue".to_string(),
+        consumer_id: "c3".to_string(),
+        consumer_group: Some("group-a".to_string()),
+        tx: c3_tx,
+    })
+    .unwrap();
+
+    // Enqueue 9 messages (should be 3 per consumer)
+    let mut msg_ids = Vec::new();
+    for i in 0u64..9 {
+        let mut msg = test_message("cg-queue");
+        msg.enqueued_at = i;
+        msg_ids.push(msg.id);
+        let (reply_tx, _) = tokio::sync::oneshot::channel();
+        tx.send(SchedulerCommand::Enqueue {
+            message: msg,
+            reply: reply_tx,
+        })
+        .unwrap();
+    }
+
+    tx.send(SchedulerCommand::Shutdown).unwrap();
+    scheduler.run();
+
+    // Collect messages from each consumer
+    let mut c1_msgs = Vec::new();
+    while let Ok(ready) = c1_rx.try_recv() {
+        c1_msgs.push(ready.msg_id);
+    }
+    let mut c2_msgs = Vec::new();
+    while let Ok(ready) = c2_rx.try_recv() {
+        c2_msgs.push(ready.msg_id);
+    }
+    let mut c3_msgs = Vec::new();
+    while let Ok(ready) = c3_rx.try_recv() {
+        c3_msgs.push(ready.msg_id);
+    }
+
+    let total = c1_msgs.len() + c2_msgs.len() + c3_msgs.len();
+    assert_eq!(total, 9, "all 9 messages should be delivered");
+
+    // Each consumer should get exactly 3 messages (round-robin in a group)
+    assert_eq!(c1_msgs.len(), 3, "c1 should get 3 messages");
+    assert_eq!(c2_msgs.len(), 3, "c2 should get 3 messages");
+    assert_eq!(c3_msgs.len(), 3, "c3 should get 3 messages");
+
+    // No duplicates
+    let mut all_ids: Vec<_> = c1_msgs
+        .iter()
+        .chain(c2_msgs.iter())
+        .chain(c3_msgs.iter())
+        .copied()
+        .collect();
+    all_ids.sort();
+    all_ids.dedup();
+    assert_eq!(all_ids.len(), 9, "no message duplicates");
+}
+
+#[test]
+fn consumer_group_rebalances_on_leave() {
+    let (tx, mut scheduler, _dir) = test_setup();
+
+    send_create_queue(&tx, "rebal-queue");
+
+    // Register 3 consumers in the same group
+    let (c1_tx, mut c1_rx) = tokio::sync::mpsc::channel(64);
+    tx.send(SchedulerCommand::RegisterConsumer {
+        queue_id: "rebal-queue".to_string(),
+        consumer_id: "c1".to_string(),
+        consumer_group: Some("grp".to_string()),
+        tx: c1_tx,
+    })
+    .unwrap();
+
+    let (c2_tx, mut c2_rx) = tokio::sync::mpsc::channel(64);
+    tx.send(SchedulerCommand::RegisterConsumer {
+        queue_id: "rebal-queue".to_string(),
+        consumer_id: "c2".to_string(),
+        consumer_group: Some("grp".to_string()),
+        tx: c2_tx,
+    })
+    .unwrap();
+
+    let (c3_tx, mut c3_rx) = tokio::sync::mpsc::channel(64);
+    tx.send(SchedulerCommand::RegisterConsumer {
+        queue_id: "rebal-queue".to_string(),
+        consumer_id: "c3".to_string(),
+        consumer_group: Some("grp".to_string()),
+        tx: c3_tx,
+    })
+    .unwrap();
+
+    // Enqueue 3 messages — one to each consumer
+    for i in 0u64..3 {
+        let mut msg = test_message("rebal-queue");
+        msg.enqueued_at = i;
+        let (reply_tx, _) = tokio::sync::oneshot::channel();
+        tx.send(SchedulerCommand::Enqueue {
+            message: msg,
+            reply: reply_tx,
+        })
+        .unwrap();
+    }
+
+    // Process all pending commands to deliver the first 3 messages
+    scheduler.handle_all_pending(&tx);
+
+    // Drain first batch
+    let mut phase1_c1 = 0;
+    while c1_rx.try_recv().is_ok() {
+        phase1_c1 += 1;
+    }
+    let mut phase1_c2 = 0;
+    while c2_rx.try_recv().is_ok() {
+        phase1_c2 += 1;
+    }
+    let mut phase1_c3 = 0;
+    while c3_rx.try_recv().is_ok() {
+        phase1_c3 += 1;
+    }
+    assert_eq!(
+        phase1_c1 + phase1_c2 + phase1_c3,
+        3,
+        "3 messages delivered in phase 1"
+    );
+
+    // Now c3 disconnects
+    tx.send(SchedulerCommand::UnregisterConsumer {
+        consumer_id: "c3".to_string(),
+    })
+    .unwrap();
+    drop(c3_rx);
+
+    // Enqueue 6 more messages — should be distributed across c1 and c2 only
+    for i in 10u64..16 {
+        let mut msg = test_message("rebal-queue");
+        msg.enqueued_at = i;
+        let (reply_tx, _) = tokio::sync::oneshot::channel();
+        tx.send(SchedulerCommand::Enqueue {
+            message: msg,
+            reply: reply_tx,
+        })
+        .unwrap();
+    }
+
+    tx.send(SchedulerCommand::Shutdown).unwrap();
+    scheduler.run();
+
+    // Collect phase 2 messages
+    let mut phase2_c1 = 0;
+    while c1_rx.try_recv().is_ok() {
+        phase2_c1 += 1;
+    }
+    let mut phase2_c2 = 0;
+    while c2_rx.try_recv().is_ok() {
+        phase2_c2 += 1;
+    }
+
+    let phase2_total = phase2_c1 + phase2_c2;
+    assert_eq!(phase2_total, 6, "all 6 messages delivered after rebalance");
+    // Each remaining consumer should get ~50% (3 each)
+    assert_eq!(phase2_c1, 3, "c1 should get 3 messages after rebalance");
+    assert_eq!(phase2_c2, 3, "c2 should get 3 messages after rebalance");
+}
+
+#[test]
+fn no_consumer_group_works_as_independent() {
+    let (tx, mut scheduler, _dir) = test_setup();
+
+    send_create_queue(&tx, "indep-queue");
+
+    // Register 2 consumers without groups (classic behavior)
+    let (c1_tx, mut c1_rx) = tokio::sync::mpsc::channel(64);
+    tx.send(SchedulerCommand::RegisterConsumer {
+        queue_id: "indep-queue".to_string(),
+        consumer_id: "c1".to_string(),
+        consumer_group: None,
+        tx: c1_tx,
+    })
+    .unwrap();
+
+    let (c2_tx, mut c2_rx) = tokio::sync::mpsc::channel(64);
+    tx.send(SchedulerCommand::RegisterConsumer {
+        queue_id: "indep-queue".to_string(),
+        consumer_id: "c2".to_string(),
+        consumer_group: None,
+        tx: c2_tx,
+    })
+    .unwrap();
+
+    // Enqueue 4 messages
+    for i in 0u64..4 {
+        let mut msg = test_message("indep-queue");
+        msg.enqueued_at = i;
+        let (reply_tx, _) = tokio::sync::oneshot::channel();
+        tx.send(SchedulerCommand::Enqueue {
+            message: msg,
+            reply: reply_tx,
+        })
+        .unwrap();
+    }
+
+    tx.send(SchedulerCommand::Shutdown).unwrap();
+    scheduler.run();
+
+    let mut c1_msgs = 0;
+    while c1_rx.try_recv().is_ok() {
+        c1_msgs += 1;
+    }
+    let mut c2_msgs = 0;
+    while c2_rx.try_recv().is_ok() {
+        c2_msgs += 1;
+    }
+
+    // Independent consumers get round-robin delivery (same as before)
+    assert_eq!(c1_msgs + c2_msgs, 4, "all messages delivered");
+    assert_eq!(c1_msgs, 2, "c1 gets 2 messages");
+    assert_eq!(c2_msgs, 2, "c2 gets 2 messages");
+}
+
+#[test]
+fn mixed_group_and_independent_consumers() {
+    let (tx, mut scheduler, _dir) = test_setup();
+
+    send_create_queue(&tx, "mix-queue");
+
+    // Register a group with 2 members
+    let (g1_tx, mut g1_rx) = tokio::sync::mpsc::channel(64);
+    tx.send(SchedulerCommand::RegisterConsumer {
+        queue_id: "mix-queue".to_string(),
+        consumer_id: "g1".to_string(),
+        consumer_group: Some("group-a".to_string()),
+        tx: g1_tx,
+    })
+    .unwrap();
+
+    let (g2_tx, mut g2_rx) = tokio::sync::mpsc::channel(64);
+    tx.send(SchedulerCommand::RegisterConsumer {
+        queue_id: "mix-queue".to_string(),
+        consumer_id: "g2".to_string(),
+        consumer_group: Some("group-a".to_string()),
+        tx: g2_tx,
+    })
+    .unwrap();
+
+    // Register an independent consumer
+    let (ind_tx, mut ind_rx) = tokio::sync::mpsc::channel(64);
+    tx.send(SchedulerCommand::RegisterConsumer {
+        queue_id: "mix-queue".to_string(),
+        consumer_id: "independent".to_string(),
+        consumer_group: None,
+        tx: ind_tx,
+    })
+    .unwrap();
+
+    // Enqueue 6 messages
+    for i in 0u64..6 {
+        let mut msg = test_message("mix-queue");
+        msg.enqueued_at = i;
+        let (reply_tx, _) = tokio::sync::oneshot::channel();
+        tx.send(SchedulerCommand::Enqueue {
+            message: msg,
+            reply: reply_tx,
+        })
+        .unwrap();
+    }
+
+    tx.send(SchedulerCommand::Shutdown).unwrap();
+    scheduler.run();
+
+    let mut g1_count = 0;
+    while g1_rx.try_recv().is_ok() {
+        g1_count += 1;
+    }
+    let mut g2_count = 0;
+    while g2_rx.try_recv().is_ok() {
+        g2_count += 1;
+    }
+    let mut ind_count = 0;
+    while ind_rx.try_recv().is_ok() {
+        ind_count += 1;
+    }
+
+    // There are 2 delivery targets: group-a and independent.
+    // Round-robin across targets: 3 messages to group-a, 3 to independent.
+    // Within group-a, round-robin: ~1-2 each.
+    let group_total = g1_count + g2_count;
+    assert_eq!(group_total + ind_count, 6, "all 6 messages delivered");
+    // Group-a gets half, independent gets half
+    assert_eq!(group_total, 3, "group-a gets 3 messages total");
+    assert_eq!(ind_count, 3, "independent gets 3 messages");
+}
+
+#[test]
+fn get_consumer_groups_returns_group_info() {
+    let (tx, mut scheduler, _dir) = test_setup();
+
+    send_create_queue(&tx, "info-queue");
+
+    // Register consumers in groups
+    let (c1_tx, _c1_rx) = tokio::sync::mpsc::channel(64);
+    tx.send(SchedulerCommand::RegisterConsumer {
+        queue_id: "info-queue".to_string(),
+        consumer_id: "c1".to_string(),
+        consumer_group: Some("grp1".to_string()),
+        tx: c1_tx,
+    })
+    .unwrap();
+
+    let (c2_tx, _c2_rx) = tokio::sync::mpsc::channel(64);
+    tx.send(SchedulerCommand::RegisterConsumer {
+        queue_id: "info-queue".to_string(),
+        consumer_id: "c2".to_string(),
+        consumer_group: Some("grp1".to_string()),
+        tx: c2_tx,
+    })
+    .unwrap();
+
+    let (c3_tx, _c3_rx) = tokio::sync::mpsc::channel(64);
+    tx.send(SchedulerCommand::RegisterConsumer {
+        queue_id: "info-queue".to_string(),
+        consumer_id: "c3".to_string(),
+        consumer_group: Some("grp2".to_string()),
+        tx: c3_tx,
+    })
+    .unwrap();
+
+    scheduler.handle_all_pending(&tx);
+
+    // Query consumer groups via GetConsumerGroups command
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    scheduler.handle_command(SchedulerCommand::GetConsumerGroups {
+        queue_filter: None,
+        reply: reply_tx,
+    });
+    let groups = reply_rx.blocking_recv().unwrap().unwrap();
+    assert_eq!(groups.len(), 2, "should have 2 groups");
+
+    let grp1 = groups.iter().find(|g| g.group_name == "grp1").unwrap();
+    assert_eq!(grp1.member_count, 2);
+    assert_eq!(grp1.queue, "info-queue");
+
+    let grp2 = groups.iter().find(|g| g.group_name == "grp2").unwrap();
+    assert_eq!(grp2.member_count, 1);
+
+    // Filter by queue
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    scheduler.handle_command(SchedulerCommand::GetConsumerGroups {
+        queue_filter: Some("info-queue".to_string()),
+        reply: reply_tx,
+    });
+    let filtered = reply_rx.blocking_recv().unwrap().unwrap();
+    assert_eq!(filtered.len(), 2);
+
+    // Filter by non-existent queue
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    scheduler.handle_command(SchedulerCommand::GetConsumerGroups {
+        queue_filter: Some("other-queue".to_string()),
+        reply: reply_tx,
+    });
+    let empty = reply_rx.blocking_recv().unwrap().unwrap();
+    assert!(empty.is_empty());
+}
+
+#[test]
+fn consumer_group_single_member_gets_all() {
+    let (tx, mut scheduler, _dir) = test_setup();
+
+    send_create_queue(&tx, "solo-queue");
+
+    // Register 1 consumer in a group
+    let (c1_tx, mut c1_rx) = tokio::sync::mpsc::channel(64);
+    tx.send(SchedulerCommand::RegisterConsumer {
+        queue_id: "solo-queue".to_string(),
+        consumer_id: "c1".to_string(),
+        consumer_group: Some("solo-grp".to_string()),
+        tx: c1_tx,
+    })
+    .unwrap();
+
+    // Enqueue 5 messages
+    for i in 0u64..5 {
+        let mut msg = test_message("solo-queue");
+        msg.enqueued_at = i;
+        let (reply_tx, _) = tokio::sync::oneshot::channel();
+        tx.send(SchedulerCommand::Enqueue {
+            message: msg,
+            reply: reply_tx,
+        })
+        .unwrap();
+    }
+
+    tx.send(SchedulerCommand::Shutdown).unwrap();
+    scheduler.run();
+
+    let mut count = 0;
+    while c1_rx.try_recv().is_ok() {
+        count += 1;
+    }
+    assert_eq!(count, 5, "solo consumer in group gets all messages");
+}
+
+#[test]
+fn multiple_groups_on_same_queue() {
+    let (tx, mut scheduler, _dir) = test_setup();
+
+    send_create_queue(&tx, "multi-grp-queue");
+
+    // Group A: 2 consumers
+    let (ga1_tx, mut ga1_rx) = tokio::sync::mpsc::channel(64);
+    tx.send(SchedulerCommand::RegisterConsumer {
+        queue_id: "multi-grp-queue".to_string(),
+        consumer_id: "ga1".to_string(),
+        consumer_group: Some("group-a".to_string()),
+        tx: ga1_tx,
+    })
+    .unwrap();
+
+    let (ga2_tx, mut ga2_rx) = tokio::sync::mpsc::channel(64);
+    tx.send(SchedulerCommand::RegisterConsumer {
+        queue_id: "multi-grp-queue".to_string(),
+        consumer_id: "ga2".to_string(),
+        consumer_group: Some("group-a".to_string()),
+        tx: ga2_tx,
+    })
+    .unwrap();
+
+    // Group B: 1 consumer
+    let (gb1_tx, mut gb1_rx) = tokio::sync::mpsc::channel(64);
+    tx.send(SchedulerCommand::RegisterConsumer {
+        queue_id: "multi-grp-queue".to_string(),
+        consumer_id: "gb1".to_string(),
+        consumer_group: Some("group-b".to_string()),
+        tx: gb1_tx,
+    })
+    .unwrap();
+
+    // Enqueue 6 messages
+    for i in 0u64..6 {
+        let mut msg = test_message("multi-grp-queue");
+        msg.enqueued_at = i;
+        let (reply_tx, _) = tokio::sync::oneshot::channel();
+        tx.send(SchedulerCommand::Enqueue {
+            message: msg,
+            reply: reply_tx,
+        })
+        .unwrap();
+    }
+
+    tx.send(SchedulerCommand::Shutdown).unwrap();
+    scheduler.run();
+
+    let mut ga1_count = 0;
+    while ga1_rx.try_recv().is_ok() {
+        ga1_count += 1;
+    }
+    let mut ga2_count = 0;
+    while ga2_rx.try_recv().is_ok() {
+        ga2_count += 1;
+    }
+    let mut gb1_count = 0;
+    while gb1_rx.try_recv().is_ok() {
+        gb1_count += 1;
+    }
+
+    let total = ga1_count + ga2_count + gb1_count;
+    assert_eq!(total, 6, "all 6 messages delivered");
+
+    // 2 delivery targets: group-a and group-b
+    // Round-robin: 3 to group-a, 3 to group-b
+    let group_a_total = ga1_count + ga2_count;
+    assert_eq!(group_a_total, 3, "group-a gets 3 messages");
+    assert_eq!(gb1_count, 3, "group-b gets 3 messages");
+}

--- a/crates/fila-core/src/broker/scheduler/tests/delivery.rs
+++ b/crates/fila-core/src/broker/scheduler/tests/delivery.rs
@@ -11,6 +11,7 @@ fn consumer_receives_enqueued_messages() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "lease-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -60,6 +61,7 @@ fn consumer_receives_pending_messages_on_register() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "pending-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -91,6 +93,7 @@ fn lease_creates_entries_in_storage() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "lease-cf-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -125,6 +128,7 @@ fn multiple_consumers_get_different_messages() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "multi-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: c1_tx,
     })
     .unwrap();
@@ -133,6 +137,7 @@ fn multiple_consumers_get_different_messages() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "multi-queue".to_string(),
         consumer_id: "c2".to_string(),
+        consumer_group: None,
         tx: c2_tx,
     })
     .unwrap();
@@ -193,6 +198,7 @@ fn unregister_consumer_stops_delivery() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "unreg-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -231,6 +237,7 @@ fn enqueue_10_messages_lease_receives_all() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "ten-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -272,6 +279,7 @@ fn delivery_skips_closed_consumer_and_delivers_to_next() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "closed-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: c1_tx,
     })
     .unwrap();
@@ -282,6 +290,7 @@ fn delivery_skips_closed_consumer_and_delivers_to_next() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "closed-queue".to_string(),
         consumer_id: "c2".to_string(),
+        consumer_group: None,
         tx: c2_tx,
     })
     .unwrap();
@@ -322,6 +331,7 @@ fn delivery_rolls_back_lease_when_all_consumers_closed() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "all-closed-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: c1_tx,
     })
     .unwrap();
@@ -331,6 +341,7 @@ fn delivery_rolls_back_lease_when_all_consumers_closed() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "all-closed-queue".to_string(),
         consumer_id: "c2".to_string(),
+        consumer_group: None,
         tx: c2_tx,
     })
     .unwrap();
@@ -377,6 +388,7 @@ fn delivery_skips_full_consumer_and_delivers_to_next() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "full-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: c1_tx,
     })
     .unwrap();
@@ -386,6 +398,7 @@ fn delivery_skips_full_consumer_and_delivers_to_next() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "full-queue".to_string(),
         consumer_id: "c2".to_string(),
+        consumer_group: None,
         tx: c2_tx,
     })
     .unwrap();
@@ -448,6 +461,7 @@ fn delivery_rolls_back_lease_when_all_consumers_full() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "all-full-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: c1_tx,
     })
     .unwrap();
@@ -456,6 +470,7 @@ fn delivery_rolls_back_lease_when_all_consumers_full() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "all-full-queue".to_string(),
         consumer_id: "c2".to_string(),
+        consumer_group: None,
         tx: c2_tx,
     })
     .unwrap();

--- a/crates/fila-core/src/broker/scheduler/tests/dlq.rs
+++ b/crates/fila-core/src/broker/scheduler/tests/dlq.rs
@@ -103,6 +103,7 @@ fn dlq_full_flow_enqueue_nack_dlq_lease() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "flow-queue".to_string(),
         consumer_id: "main-c".to_string(),
+        consumer_group: None,
         tx: main_tx,
     })
     .unwrap();
@@ -111,6 +112,7 @@ fn dlq_full_flow_enqueue_nack_dlq_lease() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "flow-queue.dlq".to_string(),
         consumer_id: "dlq-c".to_string(),
+        consumer_group: None,
         tx: dlq_tx,
     })
     .unwrap();

--- a/crates/fila-core/src/broker/scheduler/tests/fairness.rs
+++ b/crates/fila-core/src/broker/scheduler/tests/fairness.rs
@@ -11,6 +11,7 @@ fn drr_three_equal_weight_keys_get_equal_delivery() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "drr-equal".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -72,6 +73,7 @@ fn drr_single_key_backward_compatible() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "drr-single".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -112,6 +114,7 @@ fn drr_key_exhaustion_continues_other_keys() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "drr-exhaust".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -174,6 +177,7 @@ fn drr_weighted_keys_proportional_delivery() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "drr-weighted".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -291,6 +295,7 @@ fn drr_fairness_accuracy_10k_messages_6_keys() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "drr-accuracy".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -351,6 +356,7 @@ fn drr_default_weight_is_one() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "default-weight".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -400,6 +406,7 @@ fn drr_weight_zero_treated_as_one() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "weight-zero".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -502,6 +509,7 @@ fn drr_weight_update_changes_proportions() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "weight-update".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();

--- a/crates/fila-core/src/broker/scheduler/tests/list_queues.rs
+++ b/crates/fila-core/src/broker/scheduler/tests/list_queues.rs
@@ -76,6 +76,7 @@ fn list_queues_reports_nonzero_depth_and_consumers() {
     scheduler.handle_command(SchedulerCommand::RegisterConsumer {
         queue_id: "stats-q".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     });
 

--- a/crates/fila-core/src/broker/scheduler/tests/lua.rs
+++ b/crates/fila-core/src/broker/scheduler/tests/lua.rs
@@ -369,6 +369,7 @@ fn on_failure_retry_requeues_message() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "retry-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -426,6 +427,7 @@ fn on_failure_dlq_moves_message_to_dead_letter_queue() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "main-queue".to_string(),
         consumer_id: "main-consumer".to_string(),
+        consumer_group: None,
         tx: main_tx,
     })
     .unwrap();
@@ -434,6 +436,7 @@ fn on_failure_dlq_moves_message_to_dead_letter_queue() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "main-queue.dlq".to_string(),
         consumer_id: "dlq-consumer".to_string(),
+        consumer_group: None,
         tx: dlq_tx,
     })
     .unwrap();
@@ -515,6 +518,7 @@ fn on_failure_dlq_without_dlq_configured_falls_back_to_retry() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "orphan.dlq".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -573,6 +577,7 @@ fn on_failure_receives_attempt_count_and_error() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "attempts-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -581,6 +586,7 @@ fn on_failure_receives_attempt_count_and_error() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "attempts-queue.dlq".to_string(),
         consumer_id: "dlq-c1".to_string(),
+        consumer_group: None,
         tx: dlq_consumer_tx,
     })
     .unwrap();
@@ -662,6 +668,7 @@ fn on_failure_no_script_uses_default_retry() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "no-script-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -726,6 +733,7 @@ fn recovery_restores_on_failure_scripts() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "recovery-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -746,6 +754,7 @@ fn recovery_restores_on_failure_scripts() {
     tx2.send(SchedulerCommand::RegisterConsumer {
         queue_id: "recovery-queue".to_string(),
         consumer_id: "c2".to_string(),
+        consumer_group: None,
         tx: main_consumer_tx,
     })
     .unwrap();
@@ -754,6 +763,7 @@ fn recovery_restores_on_failure_scripts() {
     tx2.send(SchedulerCommand::RegisterConsumer {
         queue_id: "recovery-queue.dlq".to_string(),
         consumer_id: "dlq-c2".to_string(),
+        consumer_group: None,
         tx: dlq_consumer_tx,
     })
     .unwrap();

--- a/crates/fila-core/src/broker/scheduler/tests/mod.rs
+++ b/crates/fila-core/src/broker/scheduler/tests/mod.rs
@@ -11,6 +11,7 @@ use common::*;
 mod ack_nack;
 mod command;
 mod config;
+mod consumer_groups;
 mod delivery;
 mod dlq;
 mod enqueue;

--- a/crates/fila-core/src/broker/scheduler/tests/recovery.rs
+++ b/crates/fila-core/src/broker/scheduler/tests/recovery.rs
@@ -33,6 +33,7 @@ fn recovery_preserves_messages_after_restart() {
     tx2.send(SchedulerCommand::RegisterConsumer {
         queue_id: "recover-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -95,6 +96,7 @@ fn recovery_reclaims_expired_leases() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "reclaim-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -169,6 +171,7 @@ fn recovery_does_not_duplicate_reclaimed_messages() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "dup-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -363,6 +366,7 @@ fn recovery_preserves_non_expired_leases() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "active-lease-queue".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();

--- a/crates/fila-core/src/broker/scheduler/tests/redrive.rs
+++ b/crates/fila-core/src/broker/scheduler/tests/redrive.rs
@@ -45,6 +45,7 @@ fn redrive_moves_messages_from_dlq_to_parent_and_leasable() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "redrive-q".to_string(),
         consumer_id: "lease-after-redrive".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -281,6 +282,7 @@ fn redrive_skips_leased_messages_in_dlq() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "redrive-leased-q.dlq".to_string(),
         consumer_id: "dlq-inspector".to_string(),
+        consumer_group: None,
         tx: dlq_consumer_tx,
     })
     .unwrap();

--- a/crates/fila-core/src/broker/scheduler/tests/stats.rs
+++ b/crates/fila-core/src/broker/scheduler/tests/stats.rs
@@ -22,6 +22,7 @@ fn get_stats_returns_depth_and_in_flight() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "stats-q".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -241,6 +242,7 @@ fn get_stats_integration_multi_key_with_leases_and_throttle() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "stats-int-q".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -318,6 +320,7 @@ fn get_stats_after_ack_decreases_in_flight_and_depth() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "stats-ack-q".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();

--- a/crates/fila-core/src/broker/scheduler/tests/throttle.rs
+++ b/crates/fila-core/src/broker/scheduler/tests/throttle.rs
@@ -19,6 +19,7 @@ fn throttle_skips_throttled_message() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "throttle-q".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -69,6 +70,7 @@ fn throttle_multi_key_all_must_pass() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "multi-key-q".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -116,6 +118,7 @@ fn throttle_refill_allows_delivery() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "refill-q".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -165,6 +168,7 @@ fn throttle_skipped_key_stays_active() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "active-q".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();
@@ -205,6 +209,7 @@ fn throttle_empty_keys_unthrottled() {
     tx.send(SchedulerCommand::RegisterConsumer {
         queue_id: "unthrottled-q".to_string(),
         consumer_id: "c1".to_string(),
+        consumer_group: None,
         tx: consumer_tx,
     })
     .unwrap();

--- a/crates/fila-core/src/cluster/tests.rs
+++ b/crates/fila-core/src/cluster/tests.rs
@@ -769,6 +769,7 @@ mod tests {
             .send_command(crate::SchedulerCommand::RegisterConsumer {
                 queue_id: "orders".to_string(),
                 consumer_id: consumer_id.clone(),
+                consumer_group: None,
                 tx: ready_tx,
             })
             .unwrap();
@@ -819,6 +820,7 @@ mod tests {
             .send_command(crate::SchedulerCommand::RegisterConsumer {
                 queue_id: "ack-test".to_string(),
                 consumer_id: "c1".to_string(),
+                consumer_group: None,
                 tx: ready_tx,
             })
             .unwrap();
@@ -1172,6 +1174,7 @@ mod tests {
             .send_command(crate::SchedulerCommand::RegisterConsumer {
                 queue_id: "loss-test".to_string(),
                 consumer_id: "loss-consumer".to_string(),
+                consumer_group: None,
                 tx: ready_tx,
             })
             .unwrap();

--- a/crates/fila-core/src/error.rs
+++ b/crates/fila-core/src/error.rs
@@ -131,6 +131,12 @@ pub enum ListQueuesError {
     Storage(#[from] StorageError),
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum ConsumerGroupsError {
+    #[error(transparent)]
+    Storage(#[from] StorageError),
+}
+
 // --- Broker lifecycle/channel errors ---
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/fila-core/src/lib.rs
+++ b/crates/fila-core/src/lib.rs
@@ -8,12 +8,13 @@ pub mod storage;
 pub mod telemetry;
 
 pub use broker::{
-    AuthConfig, Broker, BrokerConfig, QueueSummary, ReadyMessage, SchedulerCommand, TlsParams,
+    AuthConfig, Broker, BrokerConfig, ConsumerGroupInfo, QueueSummary, ReadyMessage,
+    SchedulerCommand, TlsParams,
 };
 pub use error::{
-    AckError, BrokerError, BrokerResult, ConfigError, CreateQueueError, DeleteQueueError,
-    EnqueueError, ListQueuesError, NackError, RedriveError, StatsError, StorageError,
-    StorageResult,
+    AckError, BrokerError, BrokerResult, ConfigError, ConsumerGroupsError, CreateQueueError,
+    DeleteQueueError, EnqueueError, ListQueuesError, NackError, RedriveError, StatsError,
+    StorageError, StorageResult,
 };
 pub use message::Message;
 pub use queue::QueueConfig;

--- a/crates/fila-proto/proto/fila/v1/admin.proto
+++ b/crates/fila-proto/proto/fila/v1/admin.proto
@@ -20,6 +20,9 @@ service FilaAdmin {
   // Per-key ACL management.
   rpc SetAcl(SetAclRequest) returns (SetAclResponse);
   rpc GetAcl(GetAclRequest) returns (GetAclResponse);
+
+  // Consumer group inspection.
+  rpc GetConsumerGroups(GetConsumerGroupsRequest) returns (GetConsumerGroupsResponse);
 }
 
 message CreateQueueRequest {
@@ -194,4 +197,28 @@ message GetAclResponse {
   string key_id = 1;
   repeated AclPermission permissions = 2;
   bool is_superadmin = 3;
+}
+
+// --- Consumer Groups ---
+
+message GetConsumerGroupsRequest {
+  // Optional queue filter. When empty, returns groups for all queues.
+  string queue = 1;
+}
+
+/// A single member of a consumer group.
+message ConsumerGroupMember {
+  string consumer_id = 1;
+}
+
+/// A consumer group for a specific queue.
+message ConsumerGroupInfo {
+  string queue = 1;
+  string group_name = 2;
+  uint32 member_count = 3;
+  repeated ConsumerGroupMember members = 4;
+}
+
+message GetConsumerGroupsResponse {
+  repeated ConsumerGroupInfo groups = 1;
 }

--- a/crates/fila-proto/proto/fila/v1/service.proto
+++ b/crates/fila-proto/proto/fila/v1/service.proto
@@ -23,6 +23,10 @@ message EnqueueResponse {
 
 message ConsumeRequest {
   string queue = 1;
+  // Optional consumer group name. When set, the broker distributes messages
+  // across all consumers in the same group (each message goes to exactly one
+  // member). When empty, the consumer operates independently (classic behavior).
+  string consumer_group = 2;
 }
 
 message ConsumeResponse {

--- a/crates/fila-sdk/src/client.rs
+++ b/crates/fila-sdk/src/client.rs
@@ -223,8 +223,32 @@ impl FilaClient {
         &self,
         queue: &str,
     ) -> Result<impl Stream<Item = Result<ConsumeMessage, StatusError>>, ConsumeError> {
+        self.consume_inner(queue, None).await
+    }
+
+    /// Open a streaming consume connection as a member of a consumer group.
+    ///
+    /// Messages are distributed across all members of the same group for this
+    /// queue — each message goes to exactly one member. When a member disconnects,
+    /// remaining members automatically receive its share.
+    ///
+    /// See [`consume`](Self::consume) for general streaming semantics.
+    pub async fn consume_group(
+        &self,
+        queue: &str,
+        group: &str,
+    ) -> Result<impl Stream<Item = Result<ConsumeMessage, StatusError>>, ConsumeError> {
+        self.consume_inner(queue, Some(group)).await
+    }
+
+    async fn consume_inner(
+        &self,
+        queue: &str,
+        group: Option<&str>,
+    ) -> Result<impl Stream<Item = Result<ConsumeMessage, StatusError>>, ConsumeError> {
         let consume_req = ConsumeRequest {
             queue: queue.to_string(),
+            consumer_group: group.unwrap_or_default().to_string(),
         };
 
         let result = self

--- a/crates/fila-server/src/admin_service.rs
+++ b/crates/fila-server/src/admin_service.rs
@@ -6,10 +6,11 @@ use fila_core::{
 };
 use fila_proto::fila_admin_server::FilaAdmin;
 use fila_proto::{
-    AclPermission, ApiKeyInfo, ConfigEntry, CreateApiKeyRequest, CreateApiKeyResponse,
-    CreateQueueRequest, CreateQueueResponse, DeleteQueueRequest, DeleteQueueResponse,
-    GetAclRequest, GetAclResponse, GetConfigRequest, GetConfigResponse, GetStatsRequest,
-    GetStatsResponse, ListApiKeysRequest, ListApiKeysResponse, ListConfigRequest,
+    AclPermission, ApiKeyInfo, ConfigEntry, ConsumerGroupInfo as ProtoConsumerGroupInfo,
+    ConsumerGroupMember, CreateApiKeyRequest, CreateApiKeyResponse, CreateQueueRequest,
+    CreateQueueResponse, DeleteQueueRequest, DeleteQueueResponse, GetAclRequest, GetAclResponse,
+    GetConfigRequest, GetConfigResponse, GetConsumerGroupsRequest, GetConsumerGroupsResponse,
+    GetStatsRequest, GetStatsResponse, ListApiKeysRequest, ListApiKeysResponse, ListConfigRequest,
     ListConfigResponse, ListQueuesRequest, ListQueuesResponse, PerFairnessKeyStats,
     PerThrottleKeyStats, QueueInfo, RedriveRequest, RedriveResponse, RevokeApiKeyRequest,
     RevokeApiKeyResponse, SetAclRequest, SetAclResponse, SetConfigRequest, SetConfigResponse,
@@ -770,6 +771,52 @@ impl FilaAdmin for AdminService {
             })),
             None => Err(Status::not_found("api key not found")),
         }
+    }
+
+    #[instrument(skip(self))]
+    async fn get_consumer_groups(
+        &self,
+        request: Request<GetConsumerGroupsRequest>,
+    ) -> Result<Response<GetConsumerGroupsResponse>, Status> {
+        self.check_admin(&request)?;
+        let req = request.into_inner();
+
+        let queue_filter = if req.queue.is_empty() {
+            None
+        } else {
+            Some(req.queue)
+        };
+
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        self.broker
+            .send_command(SchedulerCommand::GetConsumerGroups {
+                queue_filter,
+                reply: reply_tx,
+            })
+            .map_err(IntoStatus::into_status)?;
+
+        let groups = reply_rx
+            .await
+            .map_err(|_| Status::internal("scheduler reply channel dropped"))?
+            .map_err(IntoStatus::into_status)?;
+
+        let proto_groups = groups
+            .into_iter()
+            .map(|g| ProtoConsumerGroupInfo {
+                queue: g.queue,
+                group_name: g.group_name,
+                member_count: g.member_count,
+                members: g
+                    .members
+                    .into_iter()
+                    .map(|id| ConsumerGroupMember { consumer_id: id })
+                    .collect(),
+            })
+            .collect();
+
+        Ok(Response::new(GetConsumerGroupsResponse {
+            groups: proto_groups,
+        }))
     }
 }
 

--- a/crates/fila-server/src/error.rs
+++ b/crates/fila-server/src/error.rs
@@ -1,6 +1,6 @@
 use fila_core::{
-    AckError, BrokerError, ConfigError, CreateQueueError, DeleteQueueError, EnqueueError,
-    ListQueuesError, NackError, RedriveError, StatsError,
+    AckError, BrokerError, ConfigError, ConsumerGroupsError, CreateQueueError, DeleteQueueError,
+    EnqueueError, ListQueuesError, NackError, RedriveError, StatsError,
 };
 use tonic::Status;
 
@@ -87,6 +87,14 @@ impl IntoStatus for ListQueuesError {
     fn into_status(self) -> Status {
         match self {
             ListQueuesError::Storage(e) => Status::internal(e.to_string()),
+        }
+    }
+}
+
+impl IntoStatus for ConsumerGroupsError {
+    fn into_status(self) -> Status {
+        match self {
+            ConsumerGroupsError::Storage(e) => Status::internal(e.to_string()),
         }
     }
 }

--- a/crates/fila-server/src/service.rs
+++ b/crates/fila-server/src/service.rs
@@ -243,6 +243,11 @@ impl FilaService for HotPathService {
         }
 
         let consumer_id = Uuid::now_v7().to_string();
+        let consumer_group = if req.consumer_group.is_empty() {
+            None
+        } else {
+            Some(req.consumer_group.clone())
+        };
 
         // Channel from scheduler (ReadyMessage) to converter task
         let (ready_tx, mut ready_rx) = tokio::sync::mpsc::channel::<ReadyMessage>(64);
@@ -255,6 +260,7 @@ impl FilaService for HotPathService {
             .send_command(SchedulerCommand::RegisterConsumer {
                 queue_id: req.queue.clone(),
                 consumer_id: consumer_id.clone(),
+                consumer_group,
                 tx: ready_tx,
             })
             .map_err(IntoStatus::into_status)?;


### PR DESCRIPTION
## Summary
- Add `consumer_group` parameter to the Consume RPC, allowing consumers to form groups where each message is delivered to exactly one member via round-robin
- Implement `ConsumerGroupManager` in the scheduler that tracks group membership and handles per-group round-robin delivery
- Add `GetConsumerGroups` admin RPC for inspecting active consumer groups
- Add `consume_group()` method to the Rust SDK; existing `consume()` unchanged (backward compatible)
- Delivery targets abstraction: each group counts as one target alongside independent consumers, integrating cleanly with DRR fair scheduling

## Test plan
- [x] 12 new tests: 5 unit tests for ConsumerGroupManager, 7 integration tests for scheduler delivery
- [x] 3 consumers in group each get ~33% of 9 messages (round-robin within group)
- [x] Consumer leaves group, remaining 2 get ~50% each (rebalancing)
- [x] No consumer_group = independent consumer (backward compat)
- [x] Mixed group + independent consumers on same queue
- [x] Multiple groups on same queue
- [x] GetConsumerGroups returns correct info with queue filter
- [x] Single-member group gets all messages
- [x] All 459 tests pass (up from 432), zero regressions
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add broker-managed consumer groups so each message goes to exactly one group member via round-robin, while each group counts as a single DRR delivery target. Implements story 18.1 with admin inspection and Rust SDK support.

- **New Features**
  - `Consume` RPC now accepts `consumer_group`; broker tracks membership and round-robins within the group; groups and independent consumers are scheduled fairly via DRR.
  - Scheduler: `ConsumerGroupManager` for join/leave and per-group RR; delivery refactor resolves a group to a member and falls back on full/closed channels; cleans up on leader loss.
  - Admin: `GetConsumerGroups` RPC returns queue, group name, member count, and member IDs (optional queue filter).
  - Rust SDK: added `consume_group(queue, group)`; existing `consume(queue)` remains available.

- **Migration**
  - No changes required. Use `consume_group(queue, group)` to opt in to grouping.

<sup>Written for commit 4f3d4b19f6fd4ed56c5f9c981d477755a5445712. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- bench-results-start -->
## Benchmark Results (vs main baseline)

**Baseline commit:** `ada6d7f`  **PR commit:** `67163a5`  **Threshold:** 10%

| Benchmark | Baseline | Current | Change | Unit | |
|---|---:|---:|---:|---|:---:|
| compaction_active_p99 | 0.53 | 0.47 | -9.8% | ms |  |
| compaction_idle_p99 | 0.49 | 0.48 | -2.3% | ms |  |
| compaction_p99_delta | -0.00 | -0.00 | -12.6% | ms | 🟢 |
| consumer_concurrency_100_throughput | 1902.00 | 2080.33 | +9.4% | msg/s |  |
| consumer_concurrency_10_throughput | 1934.67 | 2086.00 | +7.8% | msg/s |  |
| consumer_concurrency_1_throughput | 334.67 | 353.67 | +5.7% | msg/s |  |
| e2e_latency_p50_light | 0.42 | 0.41 | -3.8% | ms |  |
| e2e_latency_p95_light | 0.51 | 0.47 | -8.0% | ms |  |
| e2e_latency_p99_light | 0.71 | 0.58 | -18.6% | ms | 🟢 |
| enqueue_throughput_1kb | 2638.85 | 2710.79 | +2.7% | msg/s |  |
| enqueue_throughput_1kb_mbps | 2.58 | 2.65 | +2.7% | MB/s |  |
| fairness_accuracy_max_deviation | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-1 | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-2 | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-3 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-4 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-5 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_overhead_fair_throughput | 1389.71 | 1429.65 | +2.9% | msg/s |  |
| fairness_overhead_fifo_throughput | 1426.03 | 1469.88 | +3.1% | msg/s |  |
| fairness_overhead_pct | 2.55 | 2.78 | +9.2% | % |  |
| key_cardinality_10_throughput | 2367.93 | 2440.65 | +3.1% | msg/s |  |
| key_cardinality_10k_throughput | 575.76 | 598.57 | +4.0% | msg/s |  |
| key_cardinality_1k_throughput | 1080.37 | 1128.38 | +4.4% | msg/s |  |
| lua_on_enqueue_overhead_us | 22.74 | 16.41 | -27.8% | us | 🟢 |
| lua_throughput_with_hook | 1151.78 | 1183.31 | +2.7% | msg/s |  |
| memory_per_message_overhead | 3056.84 | 1733.43 | -43.3% | bytes/msg | 🟢 |
| memory_rss_idle | 145.86 | 149.57 | +2.5% | MB |  |
| memory_rss_loaded_10k | 174.84 | 167.81 | -4.0% | MB |  |

**Summary:** 0 regressed, 4 improved, 24 unchanged
<!-- bench-results-end -->
