### PR TITLE
feat: 21.4 — failure-path & fairness benchmarks

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -207,6 +207,6 @@ development_status:
   21-1-statistical-foundation-hdrhistogram-measurement-rigor: done
   21-2-competitive-benchmark-overhaul: backlog
   21-3-open-loop-load-generation-latency-under-load-benchmarks: backlog
-  21-4-failure-path-fairness-benchmarks: backlog
+  21-4-failure-path-fairness-benchmarks: done
   21-5-ci-visualization-reporting: backlog
   epic-21-retrospective: optional

--- a/_bmad-output/implementation-artifacts/stories/21-4-failure-path-fairness-benchmarks.md
+++ b/_bmad-output/implementation-artifacts/stories/21-4-failure-path-fairness-benchmarks.md
@@ -1,0 +1,28 @@
+# Story 21.4: Failure-Path & Fairness Benchmarks
+
+Status: review
+
+## Story
+
+As a developer validating Fila's behavior under adverse conditions,
+I want benchmarks for nack storms, DLQ routing overhead, poison pill isolation, and formal fairness measurement,
+so that I know the cost of failure paths and can prove Fila's fairness scheduling works correctly under load.
+
+## Tasks / Subtasks
+
+- [x] Task 1: Nack storm benchmark — 10% nack rate vs 100%-ack baseline
+- [x] Task 2: DLQ routing overhead benchmark — 5% messages exhaust retries
+- [x] Task 3: Poison pill isolation benchmark — per-fairness-key throughput
+- [x] Task 4: Add Jain's Fairness Index to existing weighted fairness benchmark
+- [x] Task 5: Add equal-weight fairness benchmark with JFI reporting
+
+## Dev Agent Record
+
+### Agent Model Used
+Claude Opus 4.6 (1M context)
+
+### File List
+- `crates/fila-bench/src/benchmarks/failure_paths.rs` — NEW: 3 failure-path benchmarks
+- `crates/fila-bench/src/benchmarks/fairness.rs` — added JFI to weighted + new equal-weight benchmark
+- `crates/fila-bench/src/benchmarks/mod.rs` — added `pub mod failure_paths`
+- `crates/fila-bench/benches/system.rs` — registered new benchmarks

--- a/crates/fila-bench/benches/system.rs
+++ b/crates/fila-bench/benches/system.rs
@@ -1,4 +1,6 @@
-use fila_bench::benchmarks::{compaction, fairness, latency, lua, memory, scaling, throughput};
+use fila_bench::benchmarks::{
+    compaction, failure_paths, fairness, latency, lua, memory, scaling, throughput,
+};
 use fila_bench::report::BenchReport;
 use fila_bench::server::BenchServer;
 
@@ -82,6 +84,38 @@ async fn run_benchmarks() {
     let results = scaling::bench_consumer_concurrency(&server).await;
     for r in results {
         report.add(r);
+    }
+
+    // 10.5. Equal-weight fairness (Jain's Fairness Index)
+    eprintln!("[10.5/10] Equal-weight fairness (Jain's Fairness Index)...");
+    let results = fairness::bench_equal_weight_fairness(&server).await;
+    for r in results {
+        report.add(r);
+    }
+
+    // Failure-path benchmarks (gated — involve nack storms and DLQ setup)
+    if std::env::var("FILA_BENCH_FAILURE_PATHS").is_ok() {
+        eprintln!("[F1] Nack storm benchmark (10% nack rate)...");
+        let results = failure_paths::bench_nack_storm(&server).await;
+        for r in results {
+            report.add(r);
+        }
+
+        eprintln!("[F2] DLQ routing overhead benchmark...");
+        let results = failure_paths::bench_dlq_routing_overhead(&server).await;
+        for r in results {
+            report.add(r);
+        }
+
+        eprintln!("[F3] Poison pill isolation benchmark...");
+        let results = failure_paths::bench_poison_pill_isolation(&server).await;
+        for r in results {
+            report.add(r);
+        }
+    } else {
+        eprintln!(
+            "[F1-F3] Failure-path benchmarks (skipped — set FILA_BENCH_FAILURE_PATHS=1 to enable)"
+        );
     }
 
     // Note: Queue depth scaling (AC 6) is skipped by default as it takes a

--- a/crates/fila-bench/src/benchmarks/failure_paths.rs
+++ b/crates/fila-bench/src/benchmarks/failure_paths.rs
@@ -1,0 +1,326 @@
+use crate::measurement::ThroughputMeter;
+use crate::progress::Progress;
+use crate::report::BenchResult;
+use crate::server::{create_queue_cli, create_queue_with_lua_cli, BenchServer};
+use std::collections::HashMap;
+use std::time::Duration;
+use tokio_stream::StreamExt;
+
+const PAYLOAD_SIZE: usize = 1024;
+const MESSAGE_COUNT: usize = 2000;
+const NACK_RATE: f64 = 0.10;
+const DLQ_EXHAUST_RATE: f64 = 0.05;
+const FAIRNESS_KEY_COUNT: usize = 5;
+const MESSAGES_PER_KEY: usize = 400;
+
+/// Benchmark: produce messages, 10% nacked (redelivered), 90% acked.
+/// Compare throughput and latency against 100%-ack baseline.
+pub async fn bench_nack_storm(server: &BenchServer) -> Vec<BenchResult> {
+    // --- Baseline: 100% ack ---
+    let baseline_queue = "bench-nack-baseline";
+    create_queue_cli(server.addr(), baseline_queue);
+    let baseline_throughput =
+        measure_consume_throughput(server, baseline_queue, |_| Action::Ack).await;
+
+    // --- Nack storm: 10% nack, 90% ack ---
+    let nack_queue = "bench-nack-storm";
+    let on_failure = r#"function on_failure(msg) return { action = "retry", delay_ms = 0 } end"#;
+    create_queue_with_lua_cli(server.addr(), nack_queue, None, Some(on_failure));
+    let mut nack_counter: usize = 0;
+    let nack_throughput = measure_consume_throughput(server, nack_queue, |_| {
+        nack_counter += 1;
+        if nack_counter.is_multiple_of(10) {
+            Action::Nack
+        } else {
+            Action::Ack
+        }
+    })
+    .await;
+
+    let degradation_pct = if baseline_throughput > 0.0 {
+        (1.0 - nack_throughput / baseline_throughput) * 100.0
+    } else {
+        0.0
+    };
+
+    vec![
+        BenchResult {
+            name: "nack_storm_baseline_throughput".to_string(),
+            value: baseline_throughput,
+            unit: "msg/s".to_string(),
+            metadata: HashMap::new(),
+        },
+        BenchResult {
+            name: "nack_storm_10pct_nack_throughput".to_string(),
+            value: nack_throughput,
+            unit: "msg/s".to_string(),
+            metadata: [("nack_rate".to_string(), serde_json::json!(NACK_RATE))]
+                .into_iter()
+                .collect(),
+        },
+        BenchResult {
+            name: "nack_storm_throughput_degradation".to_string(),
+            value: degradation_pct,
+            unit: "%".to_string(),
+            metadata: HashMap::new(),
+        },
+    ]
+}
+
+/// Benchmark: queue with on_failure hook routing to DLQ after max retries.
+/// 5% of messages exhaust retries and route to DLQ. Report throughput vs pure-ack baseline.
+pub async fn bench_dlq_routing_overhead(server: &BenchServer) -> Vec<BenchResult> {
+    // --- Baseline: 100% ack, no on_failure hook ---
+    let baseline_queue = "bench-dlq-baseline";
+    create_queue_cli(server.addr(), baseline_queue);
+    let baseline_throughput =
+        measure_consume_throughput(server, baseline_queue, |_| Action::Ack).await;
+
+    // --- DLQ workload: on_failure with max 2 retries, 5% of messages always nacked ---
+    let dlq_queue = "bench-dlq-overhead";
+    // DLQ queue must exist first (fila auto-creates <name>.dlq but we need to be safe)
+    let dlq_target = "bench-dlq-overhead.dlq";
+    create_queue_cli(server.addr(), dlq_target);
+
+    let on_failure = r#"function on_failure(msg) if msg.attempts >= 2 then return { action = "dlq" } end return { action = "retry", delay_ms = 0 } end"#;
+    create_queue_with_lua_cli(server.addr(), dlq_queue, None, Some(on_failure));
+
+    // Track which message IDs should be "poison" (always nacked).
+    // We use a simple counter: every 20th message is poison (5%).
+    let mut msg_counter: usize = 0;
+    let dlq_throughput = measure_consume_throughput(server, dlq_queue, |_msg| {
+        msg_counter += 1;
+        if msg_counter.is_multiple_of(20) {
+            Action::Nack
+        } else {
+            Action::Ack
+        }
+    })
+    .await;
+
+    let degradation_pct = if baseline_throughput > 0.0 {
+        (1.0 - dlq_throughput / baseline_throughput) * 100.0
+    } else {
+        0.0
+    };
+
+    vec![
+        BenchResult {
+            name: "dlq_routing_baseline_throughput".to_string(),
+            value: baseline_throughput,
+            unit: "msg/s".to_string(),
+            metadata: HashMap::new(),
+        },
+        BenchResult {
+            name: "dlq_routing_mixed_throughput".to_string(),
+            value: dlq_throughput,
+            unit: "msg/s".to_string(),
+            metadata: [(
+                "dlq_exhaust_rate".to_string(),
+                serde_json::json!(DLQ_EXHAUST_RATE),
+            )]
+            .into_iter()
+            .collect(),
+        },
+        BenchResult {
+            name: "dlq_routing_throughput_degradation".to_string(),
+            value: degradation_pct,
+            unit: "%".to_string(),
+            metadata: HashMap::new(),
+        },
+    ]
+}
+
+/// Benchmark: queue with multiple fairness keys. One key's messages are all nacked
+/// (poison pills), other keys ack normally. Measure per-fairness-key throughput.
+pub async fn bench_poison_pill_isolation(server: &BenchServer) -> Vec<BenchResult> {
+    let queue = "bench-poison-pill";
+    let on_enqueue = r#"function on_enqueue(msg) local key = msg.headers["fk"] or "default" return { fairness_key = key, weight = 1, throttle_keys = {} } end"#;
+    let on_failure = r#"function on_failure(msg) return { action = "retry", delay_ms = 0 } end"#;
+    create_queue_with_lua_cli(server.addr(), queue, Some(on_enqueue), Some(on_failure));
+
+    let client = fila_sdk::FilaClient::connect(server.addr())
+        .await
+        .expect("connect");
+
+    let payload = vec![0u8; PAYLOAD_SIZE];
+
+    // Keys: "key-0" through "key-4", "key-0" is the poison key
+    let keys: Vec<String> = (0..FAIRNESS_KEY_COUNT)
+        .map(|i| format!("key-{i}"))
+        .collect();
+    let poison_key = &keys[0];
+
+    // Enqueue messages for all keys
+    let total_messages = MESSAGES_PER_KEY * FAIRNESS_KEY_COUNT;
+    let mut enq_progress = Progress::new("poison pill enqueue", total_messages as u64);
+    for key in &keys {
+        for _ in 0..MESSAGES_PER_KEY {
+            let headers: HashMap<String, String> =
+                [("fk".to_string(), key.clone())].into_iter().collect();
+            client
+                .enqueue(queue, headers, payload.clone())
+                .await
+                .expect("enqueue");
+            enq_progress.inc();
+        }
+    }
+    enq_progress.finish();
+
+    // Consume and track per-key throughput.
+    // Poison key messages get nacked, others get acked.
+    let mut stream = client.consume(queue).await.expect("consume");
+    let mut per_key_acked: HashMap<String, u64> = HashMap::new();
+    let mut per_key_nacked: HashMap<String, u64> = HashMap::new();
+
+    // We want to consume at least all non-poison messages.
+    // Non-poison messages = (FAIRNESS_KEY_COUNT - 1) * MESSAGES_PER_KEY
+    let target_acks = (FAIRNESS_KEY_COUNT - 1) * MESSAGES_PER_KEY;
+    let mut total_acked: usize = 0;
+    let mut total_processed: usize = 0;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    let mut consume_progress = Progress::new("poison pill consume", target_acks as u64);
+
+    while total_acked < target_acks && tokio::time::Instant::now() < deadline {
+        let msg = tokio::time::timeout(Duration::from_secs(5), stream.next()).await;
+        let msg = match msg {
+            Ok(Some(Ok(m))) => m,
+            _ => break,
+        };
+        total_processed += 1;
+
+        if msg.fairness_key == *poison_key {
+            client.nack(queue, &msg.id, "poison").await.expect("nack");
+            *per_key_nacked.entry(msg.fairness_key.clone()).or_insert(0) += 1;
+        } else {
+            client.ack(queue, &msg.id).await.expect("ack");
+            *per_key_acked.entry(msg.fairness_key.clone()).or_insert(0) += 1;
+            total_acked += 1;
+            consume_progress.inc();
+        }
+    }
+    consume_progress.finish();
+
+    let mut results = Vec::new();
+
+    // Per-key throughput as acked messages
+    for key in &keys {
+        let acked = per_key_acked.get(key).copied().unwrap_or(0);
+        let nacked = per_key_nacked.get(key).copied().unwrap_or(0);
+        results.push(BenchResult {
+            name: format!("poison_pill_{key}_acked"),
+            value: acked as f64,
+            unit: "messages".to_string(),
+            metadata: [
+                ("nacked".to_string(), serde_json::json!(nacked)),
+                (
+                    "is_poison".to_string(),
+                    serde_json::json!(key == poison_key),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        });
+    }
+
+    // Healthy keys should each have close to MESSAGES_PER_KEY acks
+    let healthy_acked: Vec<u64> = keys
+        .iter()
+        .filter(|k| *k != poison_key)
+        .map(|k| per_key_acked.get(k).copied().unwrap_or(0))
+        .collect();
+
+    let avg_healthy = if healthy_acked.is_empty() {
+        0.0
+    } else {
+        healthy_acked.iter().sum::<u64>() as f64 / healthy_acked.len() as f64
+    };
+
+    let min_healthy = healthy_acked.iter().copied().min().unwrap_or(0);
+
+    results.push(BenchResult {
+        name: "poison_pill_healthy_avg_acked".to_string(),
+        value: avg_healthy,
+        unit: "messages".to_string(),
+        metadata: [("expected".to_string(), serde_json::json!(MESSAGES_PER_KEY))]
+            .into_iter()
+            .collect(),
+    });
+
+    results.push(BenchResult {
+        name: "poison_pill_healthy_min_acked".to_string(),
+        value: min_healthy as f64,
+        unit: "messages".to_string(),
+        metadata: HashMap::new(),
+    });
+
+    results.push(BenchResult {
+        name: "poison_pill_total_processed".to_string(),
+        value: total_processed as f64,
+        unit: "messages".to_string(),
+        metadata: HashMap::new(),
+    });
+
+    results
+}
+
+enum Action {
+    Ack,
+    Nack,
+}
+
+/// Produce MESSAGE_COUNT messages, then consume them with the given decision function.
+/// Returns the consume throughput (acked messages per second).
+async fn measure_consume_throughput<F>(server: &BenchServer, queue: &str, mut decide: F) -> f64
+where
+    F: FnMut(&fila_sdk::ConsumeMessage) -> Action,
+{
+    let client = fila_sdk::FilaClient::connect(server.addr())
+        .await
+        .expect("connect");
+
+    let payload = vec![0u8; PAYLOAD_SIZE];
+
+    // Produce messages
+    let mut enq_progress = Progress::new(&format!("{queue} enqueue"), MESSAGE_COUNT as u64);
+    for _ in 0..MESSAGE_COUNT {
+        client
+            .enqueue(queue, HashMap::new(), payload.clone())
+            .await
+            .expect("enqueue");
+        enq_progress.inc();
+    }
+    enq_progress.finish();
+
+    // Consume and ack/nack
+    let mut stream = client.consume(queue).await.expect("consume");
+    let mut meter = ThroughputMeter::start();
+    let mut acked = 0usize;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+
+    while acked < MESSAGE_COUNT && tokio::time::Instant::now() < deadline {
+        let msg = tokio::time::timeout(Duration::from_secs(5), stream.next()).await;
+        let msg = match msg {
+            Ok(Some(Ok(m))) => m,
+            _ => break,
+        };
+
+        match decide(&msg) {
+            Action::Ack => {
+                client.ack(queue, &msg.id).await.expect("ack");
+                acked += 1;
+                meter.increment();
+            }
+            Action::Nack => {
+                client
+                    .nack(queue, &msg.id, "bench-nack")
+                    .await
+                    .expect("nack");
+                // Nacked messages get redelivered, don't count toward acked total
+            }
+        }
+    }
+
+    meter.msg_per_sec()
+}

--- a/crates/fila-bench/src/benchmarks/fairness.rs
+++ b/crates/fila-bench/src/benchmarks/fairness.rs
@@ -156,6 +156,173 @@ pub async fn bench_fairness_accuracy(server: &BenchServer) -> Vec<BenchResult> {
             .collect(),
     });
 
+    // Jain's Fairness Index on normalized ratios (actual/expected).
+    // Formula: (sum(x_i))^2 / (n * sum(x_i^2))
+    // For weighted fairness, x_i = actual_share / expected_share (normalized ratio).
+    // Perfect fairness = 1.0, worst case = 1/n.
+    let normalized_ratios: Vec<f64> = weights
+        .iter()
+        .map(|(tenant, weight)| {
+            let expected_share = *weight as f64 / total_weight as f64;
+            let actual_count = delivery_counts.get(tenant).copied().unwrap_or(0);
+            let actual_share = actual_count as f64 / window_size as f64;
+            if expected_share > 0.0 {
+                actual_share / expected_share
+            } else {
+                0.0
+            }
+        })
+        .collect();
+
+    let n = normalized_ratios.len() as f64;
+    let sum: f64 = normalized_ratios.iter().sum();
+    let sum_sq: f64 = normalized_ratios.iter().map(|x| x * x).sum();
+    let jfi = if n > 0.0 && sum_sq > 0.0 {
+        (sum * sum) / (n * sum_sq)
+    } else {
+        0.0
+    };
+
+    results.push(BenchResult {
+        name: "fairness_accuracy_jains_index".to_string(),
+        value: jfi,
+        unit: "index".to_string(),
+        metadata: [
+            (
+                "description".to_string(),
+                serde_json::json!("Jain's Fairness Index on normalized ratios (actual/expected)"),
+            ),
+            (
+                "target".to_string(),
+                serde_json::json!(">= 0.95 for equal-weight"),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    });
+
+    results
+}
+
+/// Measure fairness accuracy across equal-weight keys and report Jain's Fairness Index.
+///
+/// With equal weights, the scheduler should deliver messages uniformly across keys.
+/// JFI >= 0.95 is the target for equal-weight fairness.
+pub async fn bench_equal_weight_fairness(server: &BenchServer) -> Vec<BenchResult> {
+    let queue = "bench-fairness-equal";
+    let on_enqueue = r#"function on_enqueue(msg) local key = msg.headers["tenant_id"] or "default" return { fairness_key = key, weight = 1, throttle_keys = {} } end"#;
+    create_queue_with_lua_cli(server.addr(), queue, Some(on_enqueue), None);
+
+    let client = fila_sdk::FilaClient::connect(server.addr())
+        .await
+        .expect("connect");
+
+    let key_count = 5;
+    let messages_per_key = 2000;
+    let keys: Vec<String> = (1..=key_count).map(|i| format!("tenant-{i}")).collect();
+
+    // Enqueue messages for all keys (equal weight)
+    let payload = vec![0u8; PAYLOAD_SIZE];
+    let total_enqueued = messages_per_key * key_count;
+    let mut enq_progress = Progress::new("equal-weight enqueue", total_enqueued as u64);
+    for key in &keys {
+        for _ in 0..messages_per_key {
+            let headers: HashMap<String, String> = [("tenant_id".to_string(), key.clone())]
+                .into_iter()
+                .collect();
+            client
+                .enqueue(queue, headers, payload.clone())
+                .await
+                .expect("enqueue");
+            enq_progress.inc();
+        }
+    }
+    enq_progress.finish();
+
+    // Consume a window (half the total)
+    let window_size = total_enqueued / 2;
+    let mut stream = client.consume(queue).await.expect("consume");
+    let mut delivery_counts: HashMap<String, u64> = HashMap::new();
+    let mut consume_progress = Progress::new("equal-weight consume", window_size as u64);
+
+    for _ in 0..window_size {
+        if let Some(Ok(msg)) = stream.next().await {
+            *delivery_counts.entry(msg.fairness_key.clone()).or_insert(0) += 1;
+            client.ack(queue, &msg.id).await.expect("ack");
+            consume_progress.inc();
+        }
+    }
+    consume_progress.finish();
+
+    let mut results = Vec::new();
+    let expected_share = 1.0 / key_count as f64;
+    let mut max_deviation = 0.0f64;
+
+    for key in &keys {
+        let actual_count = delivery_counts.get(key).copied().unwrap_or(0);
+        let actual_share = actual_count as f64 / window_size as f64;
+        let deviation = (actual_share - expected_share).abs() / expected_share * 100.0;
+        max_deviation = max_deviation.max(deviation);
+
+        results.push(BenchResult {
+            name: format!("equal_weight_fairness_{key}"),
+            value: deviation,
+            unit: "% deviation".to_string(),
+            metadata: [
+                (
+                    "expected_share".to_string(),
+                    serde_json::json!(expected_share),
+                ),
+                ("actual_share".to_string(), serde_json::json!(actual_share)),
+                ("actual_count".to_string(), serde_json::json!(actual_count)),
+            ]
+            .into_iter()
+            .collect(),
+        });
+    }
+
+    results.push(BenchResult {
+        name: "equal_weight_fairness_max_deviation".to_string(),
+        value: max_deviation,
+        unit: "% deviation".to_string(),
+        metadata: HashMap::new(),
+    });
+
+    // Jain's Fairness Index for equal-weight case.
+    // x_i = actual_share / expected_share (all expected shares are equal).
+    let normalized_ratios: Vec<f64> = keys
+        .iter()
+        .map(|key| {
+            let actual_count = delivery_counts.get(key).copied().unwrap_or(0);
+            let actual_share = actual_count as f64 / window_size as f64;
+            actual_share / expected_share
+        })
+        .collect();
+
+    let n = normalized_ratios.len() as f64;
+    let sum: f64 = normalized_ratios.iter().sum();
+    let sum_sq: f64 = normalized_ratios.iter().map(|x| x * x).sum();
+    let jfi = if n > 0.0 && sum_sq > 0.0 {
+        (sum * sum) / (n * sum_sq)
+    } else {
+        0.0
+    };
+
+    results.push(BenchResult {
+        name: "equal_weight_fairness_jains_index".to_string(),
+        value: jfi,
+        unit: "index".to_string(),
+        metadata: [
+            (
+                "description".to_string(),
+                serde_json::json!("Jain's Fairness Index for equal-weight keys"),
+            ),
+            ("target".to_string(), serde_json::json!(">= 0.95")),
+        ]
+        .into_iter()
+        .collect(),
+    });
+
     results
 }
 

--- a/crates/fila-bench/src/benchmarks/mod.rs
+++ b/crates/fila-bench/src/benchmarks/mod.rs
@@ -1,4 +1,5 @@
 pub mod compaction;
+pub mod failure_paths;
 pub mod fairness;
 pub mod latency;
 pub mod lua;


### PR DESCRIPTION
## Summary

- New `failure_paths.rs` module with 3 benchmarks: nack storm (10% nack rate), DLQ routing overhead (5% exhaust retries), poison pill isolation (per-fairness-key throughput)
- Add Jain's Fairness Index to existing weighted fairness benchmark
- New equal-weight fairness benchmark with JFI reporting (target >= 0.95)
- Failure-path benchmarks gated behind `FILA_BENCH_FAILURE_PATHS=1`

## Test plan

- [x] `cargo check -p fila-bench` passes
- [x] 19/19 tests pass
- [x] Clippy clean, fmt clean
- [ ] CI passes
- [ ] Cubic review addressed

Epic 21: Trustworthy Benchmark Suite — Story 21.4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three failure-path benchmarks and Jain's Fairness Index reporting to quantify failure-mode overhead and verify fairness. Addresses Epic 21 — Story 21.4, including a new equal‑weight fairness benchmark targeting JFI ≥ 0.95.

- **New Features**
  - Failure-path benches: nack storm (10%), DLQ routing overhead (5% exhaust), and poison pill isolation (per-key throughput).
  - Added JFI to the weighted fairness benchmark; added equal-weight fairness benchmark with JFI target ≥ 0.95.
  - Failure-path benches are opt-in; set FILA_BENCH_FAILURE_PATHS=1 to run them.

<sup>Written for commit 68e1d25b27a4d8e40b2d3644a76090988edff7c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- bench-results-start -->
## Benchmark Results (vs main baseline)

**Baseline commit:** `418fb5f`  **PR commit:** `972988a`  **Threshold:** 10%

| Benchmark | Baseline | Current | Change | Unit | |
|---|---:|---:|---:|---|:---:|
| compaction_active_enqueue_max | — | 2.08 | new | ms | (new) |
| compaction_active_enqueue_p50 | — | 0.56 | new | ms | (new) |
| compaction_active_enqueue_p95 | — | 0.64 | new | ms | (new) |
| compaction_active_enqueue_p99 | — | 0.71 | new | ms | (new) |
| compaction_active_enqueue_p99_9 | — | 0.76 | new | ms | (new) |
| compaction_active_enqueue_p99_99 | — | 1.08 | new | ms | (new) |
| compaction_idle_enqueue_max | — | 4.86 | new | ms | (new) |
| compaction_idle_enqueue_p50 | — | 0.38 | new | ms | (new) |
| compaction_idle_enqueue_p95 | — | 0.43 | new | ms | (new) |
| compaction_idle_enqueue_p99 | — | 0.47 | new | ms | (new) |
| compaction_idle_enqueue_p99_9 | — | 0.67 | new | ms | (new) |
| compaction_idle_enqueue_p99_99 | — | 0.84 | new | ms | (new) |
| compaction_p99_delta | -0.01 | 0.21 | +2444.6% | ms | 🔴 |
| consumer_concurrency_100_throughput | 2013.00 | 1814.33 | -9.9% | msg/s |  |
| consumer_concurrency_10_throughput | 2060.00 | 1906.33 | -7.5% | msg/s |  |
| consumer_concurrency_1_throughput | 346.00 | 322.33 | -6.8% | msg/s |  |
| e2e_latency_light_max | — | 1.45 | new | ms | (new) |
| e2e_latency_light_p50 | — | 0.40 | new | ms | (new) |
| e2e_latency_light_p95 | — | 0.45 | new | ms | (new) |
| e2e_latency_light_p99 | — | 0.50 | new | ms | (new) |
| e2e_latency_light_p99_9 | — | 0.61 | new | ms | (new) |
| e2e_latency_light_p99_99 | — | 0.81 | new | ms | (new) |
| enqueue_throughput_1kb | 2755.15 | 2723.14 | -1.2% | msg/s |  |
| enqueue_throughput_1kb_mbps | 2.69 | 2.66 | -1.2% | MB/s |  |
| equal_weight_fairness_jains_index | — | 1.00 | new | index | (new) |
| equal_weight_fairness_max_deviation | — | 0.00 | new | % deviation | (new) |
| equal_weight_fairness_tenant-1 | — | 0.00 | new | % deviation | (new) |
| equal_weight_fairness_tenant-2 | — | 0.00 | new | % deviation | (new) |
| equal_weight_fairness_tenant-3 | — | 0.00 | new | % deviation | (new) |
| equal_weight_fairness_tenant-4 | — | 0.00 | new | % deviation | (new) |
| equal_weight_fairness_tenant-5 | — | 0.00 | new | % deviation | (new) |
| fairness_accuracy_jains_index | — | 1.00 | new | index | (new) |
| fairness_accuracy_max_deviation | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-1 | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-2 | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-3 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-4 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-5 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_overhead_fair_throughput | 1380.93 | 1401.50 | +1.5% | msg/s |  |
| fairness_overhead_fifo_throughput | 1411.89 | 1449.10 | +2.6% | msg/s |  |
| fairness_overhead_pct | 2.22 | 2.83 | +27.6% | % | 🔴 |
| key_cardinality_10_throughput | 2446.92 | 1675.94 | -31.5% | msg/s | 🔴 |
| key_cardinality_10k_throughput | 575.14 | 512.99 | -10.8% | msg/s | 🔴 |
| key_cardinality_1k_throughput | 1078.32 | 855.78 | -20.6% | msg/s | 🔴 |
| lua_on_enqueue_overhead_us | 23.30 | 20.15 | -13.5% | us | 🟢 |
| lua_throughput_with_hook | 1087.49 | 1174.18 | +8.0% | msg/s |  |
| memory_per_message_overhead | 3260.01 | 81.92 | -97.5% | bytes/msg | 🟢 |
| memory_rss_idle | 140.23 | 268.54 | +91.5% | MB | 🔴 |
| memory_rss_loaded_10k | 172.54 | 269.71 | +56.3% | MB | 🔴 |

**Summary:** 7 regressed, 2 improved, 40 unchanged

> ⚠️ **Performance regression detected** — 7 metric(s) exceeded the 10% threshold
<!-- bench-results-end -->
