### PR TITLE
feat: flamegraph generation tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 # Benchmark output
 bench-results.json
 bench/competitive/results/
+
+# Flamegraph output
+target/flamegraphs/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: flamegraph flamegraph-lifecycle flamegraph-consume flamegraph-batch
+
+# Generate a CPU flamegraph with sensible defaults (enqueue-only, 1KB, 30s).
+flamegraph:
+	./scripts/flamegraph.sh --workload enqueue-only --duration 30 --message-size 1024
+
+# Full message lifecycle (concurrent produce + consume + ack).
+flamegraph-lifecycle:
+	./scripts/flamegraph.sh --workload lifecycle --duration 30 --message-size 1024
+
+# Consume-only workload (pre-fills queue, then profiles consumption).
+flamegraph-consume:
+	./scripts/flamegraph.sh --workload consume-only --duration 30 --message-size 1024
+
+# Batch enqueue workload (auto-batching enabled).
+flamegraph-batch:
+	./scripts/flamegraph.sh --workload batch-enqueue --duration 30 --message-size 1024

--- a/crates/fila-bench/Cargo.toml
+++ b/crates/fila-bench/Cargo.toml
@@ -38,6 +38,10 @@ name = "bench-competitive"
 path = "src/bin/bench-competitive.rs"
 required-features = ["competitive"]
 
+[[bin]]
+name = "profile-workload"
+path = "src/bin/profile-workload.rs"
+
 [[bench]]
 name = "system"
 harness = false

--- a/crates/fila-bench/src/bin/profile-workload.rs
+++ b/crates/fila-bench/src/bin/profile-workload.rs
@@ -1,0 +1,281 @@
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use fila_bench::server::{create_queue_cli, BenchServer};
+use fila_sdk::{BatchMode, ConnectOptions, FilaClient};
+use tokio_stream::StreamExt;
+
+/// Profiling workload driver for flamegraph generation.
+///
+/// Starts a fila-server, runs a configurable workload, and exits.
+/// Designed to be invoked by `scripts/flamegraph.sh` under a profiler.
+///
+/// Environment variables:
+///   PROFILE_WORKLOAD   - enqueue-only, consume-only, lifecycle, batch-enqueue
+///   PROFILE_DURATION   - seconds to run (default: 30)
+///   PROFILE_MSG_SIZE   - message payload size in bytes (default: 1024)
+///   PROFILE_CONCURRENCY- number of concurrent producers/consumers (default: 1)
+///   PROFILE_SERVER_ADDR- if set, connect to an external server instead of starting one
+#[tokio::main]
+async fn main() {
+    let workload = std::env::var("PROFILE_WORKLOAD").unwrap_or_else(|_| "enqueue-only".to_string());
+    let duration_secs: u64 = std::env::var("PROFILE_DURATION")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(30);
+    let msg_size: usize = std::env::var("PROFILE_MSG_SIZE")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1024);
+    let concurrency: usize = std::env::var("PROFILE_CONCURRENCY")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1);
+
+    let duration = Duration::from_secs(duration_secs);
+    let payload = vec![0x42u8; msg_size];
+    let queue_name = "profile-queue";
+
+    // Start embedded server or connect to external.
+    let _server;
+    let addr = match std::env::var("PROFILE_SERVER_ADDR") {
+        Ok(a) => a,
+        Err(_) => {
+            let s = BenchServer::start();
+            let a = s.addr().to_string();
+            _server = s;
+            a
+        }
+    };
+
+    // Create the queue.
+    create_queue_cli(&addr, queue_name);
+
+    eprintln!(
+        "workload={workload} duration={duration_secs}s msg_size={msg_size}B concurrency={concurrency} addr={addr}"
+    );
+
+    let start = Instant::now();
+
+    match workload.as_str() {
+        "enqueue-only" => run_enqueue_only(&addr, queue_name, &payload, concurrency, duration).await,
+        "consume-only" => run_consume_only(&addr, queue_name, &payload, concurrency, duration).await,
+        "lifecycle" => run_lifecycle(&addr, queue_name, &payload, concurrency, duration).await,
+        "batch-enqueue" => {
+            run_batch_enqueue(&addr, queue_name, &payload, concurrency, duration).await
+        }
+        other => {
+            eprintln!("unknown workload: {other}");
+            eprintln!("available: enqueue-only, consume-only, lifecycle, batch-enqueue");
+            std::process::exit(1);
+        }
+    }
+
+    let elapsed = start.elapsed();
+    eprintln!("workload complete in {:.1}s", elapsed.as_secs_f64());
+}
+
+async fn connect(addr: &str) -> FilaClient {
+    FilaClient::connect_with_options(
+        ConnectOptions::new(addr)
+            .with_timeout(Duration::from_secs(30))
+            .with_batch_mode(BatchMode::Disabled),
+    )
+    .await
+    .expect("connect to fila-server")
+}
+
+async fn connect_with_batching(addr: &str) -> FilaClient {
+    FilaClient::connect_with_options(
+        ConnectOptions::new(addr).with_timeout(Duration::from_secs(30)),
+    )
+    .await
+    .expect("connect to fila-server")
+}
+
+async fn run_enqueue_only(
+    addr: &str,
+    queue: &str,
+    payload: &[u8],
+    concurrency: usize,
+    duration: Duration,
+) {
+    let mut handles = Vec::new();
+    for _ in 0..concurrency {
+        let client = connect(addr).await;
+        let q = queue.to_string();
+        let p = payload.to_vec();
+        let d = duration;
+        handles.push(tokio::spawn(async move {
+            let deadline = Instant::now() + d;
+            let mut count = 0u64;
+            while Instant::now() < deadline {
+                client
+                    .enqueue(&q, HashMap::new(), p.clone())
+                    .await
+                    .expect("enqueue");
+                count += 1;
+            }
+            count
+        }));
+    }
+    let mut total = 0u64;
+    for h in handles {
+        total += h.await.unwrap();
+    }
+    eprintln!("enqueued {total} messages");
+}
+
+async fn run_consume_only(
+    addr: &str,
+    queue: &str,
+    payload: &[u8],
+    concurrency: usize,
+    duration: Duration,
+) {
+    // Pre-fill the queue with messages.
+    let prefill_count = 10_000;
+    let client = connect(addr).await;
+    for _ in 0..prefill_count {
+        client
+            .enqueue(queue, HashMap::new(), payload.to_vec())
+            .await
+            .expect("prefill enqueue");
+    }
+    eprintln!("prefilled {prefill_count} messages");
+
+    let mut handles = Vec::new();
+    for _ in 0..concurrency {
+        let c = connect(addr).await;
+        let q = queue.to_string();
+        let d = duration;
+        handles.push(tokio::spawn(async move {
+            let deadline = Instant::now() + d;
+            let mut count = 0u64;
+            let mut stream = c.consume(&q).await.expect("consume");
+            while Instant::now() < deadline {
+                match tokio::time::timeout(Duration::from_secs(1), stream.next()).await {
+                    Ok(Some(Ok(msg))) => {
+                        c.ack(&q, &msg.id).await.expect("ack");
+                        count += 1;
+                    }
+                    Ok(Some(Err(e))) => {
+                        eprintln!("consume error: {e}");
+                        break;
+                    }
+                    Ok(None) => break,
+                    Err(_) => continue, // timeout, try again
+                }
+            }
+            count
+        }));
+    }
+    let mut total = 0u64;
+    for h in handles {
+        total += h.await.unwrap();
+    }
+    eprintln!("consumed {total} messages");
+}
+
+async fn run_lifecycle(
+    addr: &str,
+    queue: &str,
+    payload: &[u8],
+    concurrency: usize,
+    duration: Duration,
+) {
+    // Run producers and consumers concurrently.
+    let mut handles = Vec::new();
+
+    // Producers.
+    for _ in 0..concurrency {
+        let client = connect(addr).await;
+        let q = queue.to_string();
+        let p = payload.to_vec();
+        let d = duration;
+        handles.push(tokio::spawn(async move {
+            let deadline = Instant::now() + d;
+            let mut count = 0u64;
+            while Instant::now() < deadline {
+                client
+                    .enqueue(&q, HashMap::new(), p.clone())
+                    .await
+                    .expect("enqueue");
+                count += 1;
+            }
+            ("producer", count)
+        }));
+    }
+
+    // Consumers.
+    for _ in 0..concurrency {
+        let c = connect(addr).await;
+        let q = queue.to_string();
+        let d = duration;
+        handles.push(tokio::spawn(async move {
+            let deadline = Instant::now() + d;
+            let mut count = 0u64;
+            let mut stream = c.consume(&q).await.expect("consume");
+            while Instant::now() < deadline {
+                match tokio::time::timeout(Duration::from_secs(1), stream.next()).await {
+                    Ok(Some(Ok(msg))) => {
+                        c.ack(&q, &msg.id).await.expect("ack");
+                        count += 1;
+                    }
+                    Ok(Some(Err(e))) => {
+                        eprintln!("consume error: {e}");
+                        break;
+                    }
+                    Ok(None) => break,
+                    Err(_) => continue,
+                }
+            }
+            ("consumer", count)
+        }));
+    }
+
+    let mut produced = 0u64;
+    let mut consumed = 0u64;
+    for h in handles {
+        let (role, count) = h.await.unwrap();
+        match role {
+            "producer" => produced += count,
+            "consumer" => consumed += count,
+            _ => {}
+        }
+    }
+    eprintln!("produced {produced}, consumed {consumed}");
+}
+
+async fn run_batch_enqueue(
+    addr: &str,
+    queue: &str,
+    payload: &[u8],
+    concurrency: usize,
+    duration: Duration,
+) {
+    let mut handles = Vec::new();
+    for _ in 0..concurrency {
+        let client = connect_with_batching(addr).await;
+        let q = queue.to_string();
+        let p = payload.to_vec();
+        let d = duration;
+        handles.push(tokio::spawn(async move {
+            let deadline = Instant::now() + d;
+            let mut count = 0u64;
+            while Instant::now() < deadline {
+                client
+                    .enqueue(&q, HashMap::new(), p.clone())
+                    .await
+                    .expect("enqueue");
+                count += 1;
+            }
+            count
+        }));
+    }
+    let mut total = 0u64;
+    for h in handles {
+        total += h.await.unwrap();
+    }
+    eprintln!("batch-enqueued {total} messages");
+}

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,185 @@
+# Profiling Fila
+
+This guide covers how to generate and interpret CPU flamegraphs for the Fila message broker.
+
+## Prerequisites
+
+### Install cargo-flamegraph
+
+```bash
+cargo install flamegraph
+```
+
+### Platform-specific setup
+
+**macOS (DTrace)**
+
+DTrace is built into macOS. No additional tools are needed, but System Integrity Protection (SIP) may limit profiling. If `cargo flamegraph` fails with permission errors:
+
+1. Run with `sudo` (the script uses `--root` by default), or
+2. Partially disable SIP for DTrace (see [Apple docs](https://developer.apple.com/documentation/security/disabling_and_enabling_system_integrity_protection))
+
+**Linux (perf)**
+
+Install the `perf` tool for your kernel:
+
+```bash
+# Ubuntu/Debian
+sudo apt install linux-tools-common linux-tools-$(uname -r)
+
+# Fedora
+sudo dnf install perf
+```
+
+You may also need to adjust `perf_event_paranoid`:
+
+```bash
+sudo sysctl kernel.perf_event_paranoid=1
+```
+
+## Generating flamegraphs
+
+### Quick start
+
+```bash
+# Default: enqueue-only workload, 1KB messages, 30 seconds
+make flamegraph
+
+# Or use the script directly with options
+./scripts/flamegraph.sh --workload lifecycle --duration 60 --message-size 4096 --concurrency 4
+```
+
+### Available workloads
+
+| Workload | Description |
+|----------|-------------|
+| `enqueue-only` | Pure enqueue throughput. Measures the write path: gRPC receive, storage write, DRR scheduling. |
+| `consume-only` | Pre-fills the queue, then profiles consume + ack. Measures the read path: DRR delivery, gRPC streaming, ack processing. |
+| `lifecycle` | Concurrent producers and consumers. Realistic mixed workload. |
+| `batch-enqueue` | Enqueue with auto-batching enabled. Profiles the Nagle-style batcher and BatchEnqueue RPC path. |
+
+### Script options
+
+```
+--workload NAME     enqueue-only|consume-only|lifecycle|batch-enqueue (default: enqueue-only)
+--duration SECS     how long to run the workload (default: 30)
+--message-size N    payload size in bytes (default: 1024)
+--concurrency N     number of concurrent producers/consumers (default: 1)
+--output PATH       output SVG path (default: target/flamegraphs/<workload>-<timestamp>.svg)
+--help              show help
+```
+
+### Make targets
+
+```bash
+make flamegraph            # enqueue-only, 1KB, 30s
+make flamegraph-lifecycle  # lifecycle, 1KB, 30s
+make flamegraph-consume    # consume-only, 1KB, 30s
+make flamegraph-batch      # batch-enqueue, 1KB, 30s
+```
+
+## Interpreting flamegraphs
+
+Open the generated SVG in a browser. The flamegraph is interactive: click on a stack frame to zoom in, click "Reset Zoom" to return.
+
+### Reading the graph
+
+- **Width** = proportion of CPU time. Wider frames consumed more CPU.
+- **Y-axis** = call stack depth. The bottom is the entry point, each layer up is a deeper function call.
+- **Color** has no semantic meaning (it aids visual distinction).
+
+### Common patterns to look for
+
+**Wide RocksDB stacks**
+
+If frames under `rocksdb::` dominate the flamegraph, the storage layer is the bottleneck. Look for:
+
+- `rocksdb::DB::put` / `rocksdb::DB::write` — write path bound by disk I/O or WAL sync
+- `rocksdb::DB::get` / `rocksdb::DB::multi_get` — read path bound by block cache misses
+- `rocksdb::DB::iterator` — scan operations doing too much work
+
+Possible actions: tune RocksDB block cache size, adjust write buffer settings, check if compaction is keeping up.
+
+**Wide tonic/hyper stacks**
+
+If frames under `tonic::` or `hyper::` are wide, gRPC serialization or HTTP/2 framing is significant. Look for:
+
+- `prost::Message::encode` / `decode` — protobuf serialization overhead
+- `h2::` — HTTP/2 frame processing
+- `tonic::transport::` — connection management
+
+Possible actions: enable batching to amortize per-message overhead, check if message payloads are unnecessarily large.
+
+**Wide tokio stacks**
+
+If frames under `tokio::runtime::` are wide, the async runtime is spending time on scheduling rather than application logic. Look for:
+
+- `tokio::runtime::park` — idle time (good in low-load profiles, suspicious under high load)
+- `tokio::sync::mpsc` — channel contention between tasks
+- `tokio::task::waker` — excessive wakeups
+
+Possible actions: reduce cross-task channel usage, batch work to reduce task switches.
+
+**Wide mlua/Lua stacks**
+
+If frames under `mlua::` are wide, Lua hook execution is a bottleneck. This is expected for queues with complex on_enqueue or on_failure hooks.
+
+Possible actions: simplify Lua scripts, check if the circuit breaker is firing frequently.
+
+**Allocation-heavy profiles**
+
+If `alloc::` or `__rust_alloc` frames are wide, memory allocation is significant. Common sources:
+
+- `Vec::push` with frequent reallocations — pre-allocate with `with_capacity`
+- `String::from` / `to_string` on hot paths — consider `&str` or `Cow`
+- `clone()` in tight loops — investigate zero-copy alternatives
+
+## Comparing before/after
+
+Generate flamegraphs before and after a change to visually compare:
+
+```bash
+# Before
+./scripts/flamegraph.sh --workload enqueue-only --output target/flamegraphs/before.svg
+
+# Make your changes...
+
+# After
+./scripts/flamegraph.sh --workload enqueue-only --output target/flamegraphs/after.svg
+```
+
+Open both SVGs side by side in browser tabs and look for frames that grew or shrank.
+
+## Troubleshooting
+
+### "dtrace: system integrity protection is on, some features will not be available"
+
+This warning is normal on macOS. DTrace still works for basic profiling. If the resulting flamegraph is empty, you may need to run with `sudo`:
+
+```bash
+sudo ./scripts/flamegraph.sh --workload enqueue-only
+```
+
+### "perf_event_open: Permission denied"
+
+On Linux, set:
+
+```bash
+sudo sysctl kernel.perf_event_paranoid=1
+```
+
+### Empty or very small flamegraph
+
+The workload may have completed too quickly. Increase the duration:
+
+```bash
+./scripts/flamegraph.sh --duration 60
+```
+
+### "fila-server binary not found"
+
+The script builds release binaries automatically, but if it fails, build manually:
+
+```bash
+cargo build --release --bin fila-server --bin profile-workload
+```

--- a/scripts/flamegraph.sh
+++ b/scripts/flamegraph.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+#
+# Generate CPU flamegraphs for Fila workloads.
+#
+# Prerequisites:
+#   macOS: cargo install flamegraph (uses DTrace, no extra setup)
+#   Linux: cargo install flamegraph + perf (linux-tools-common)
+#
+# Usage:
+#   ./scripts/flamegraph.sh [OPTIONS]
+#
+# Options:
+#   --workload NAME    enqueue-only|consume-only|lifecycle|batch-enqueue (default: enqueue-only)
+#   --duration SECS    how long to run the workload (default: 30)
+#   --message-size N   payload size in bytes (default: 1024)
+#   --concurrency N    number of concurrent producers/consumers (default: 1)
+#   --heap             generate allocation flamegraph via DHAT
+#   --output PATH      output SVG path (default: target/flamegraphs/<workload>-<timestamp>.svg)
+#   --help             show this help
+#
+set -euo pipefail
+
+WORKLOAD="enqueue-only"
+DURATION=30
+MSG_SIZE=1024
+CONCURRENCY=1
+HEAP=false
+OUTPUT=""
+
+usage() {
+    sed -n '/^# Usage:/,/^[^#]/p' "$0" | head -n -1 | sed 's/^# *//'
+    echo ""
+    echo "Options:"
+    echo "  --workload NAME    enqueue-only|consume-only|lifecycle|batch-enqueue (default: enqueue-only)"
+    echo "  --duration SECS    how long to run the workload (default: 30)"
+    echo "  --message-size N   payload size in bytes (default: 1024)"
+    echo "  --concurrency N    number of concurrent producers/consumers (default: 1)"
+    echo "  --heap             generate allocation flamegraph via DHAT"
+    echo "  --output PATH      output SVG path (default: target/flamegraphs/<workload>-<timestamp>.svg)"
+    echo "  --help             show this help"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --workload)
+            WORKLOAD="$2"
+            shift 2
+            ;;
+        --duration)
+            DURATION="$2"
+            shift 2
+            ;;
+        --message-size)
+            MSG_SIZE="$2"
+            shift 2
+            ;;
+        --concurrency)
+            CONCURRENCY="$2"
+            shift 2
+            ;;
+        --heap)
+            HEAP=true
+            shift
+            ;;
+        --output)
+            OUTPUT="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unknown option: $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+# Validate workload name.
+case "$WORKLOAD" in
+    enqueue-only|consume-only|lifecycle|batch-enqueue) ;;
+    *)
+        echo "error: unknown workload '$WORKLOAD'"
+        echo "available: enqueue-only, consume-only, lifecycle, batch-enqueue"
+        exit 1
+        ;;
+esac
+
+# Resolve project root (parent of scripts/).
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+# Output directory.
+FLAMEGRAPH_DIR="$ROOT/target/flamegraphs"
+mkdir -p "$FLAMEGRAPH_DIR"
+
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+if [[ -z "$OUTPUT" ]]; then
+    OUTPUT="$FLAMEGRAPH_DIR/${WORKLOAD}-${TIMESTAMP}.svg"
+fi
+
+echo "=== fila flamegraph ==="
+echo "workload:    $WORKLOAD"
+echo "duration:    ${DURATION}s"
+echo "msg_size:    ${MSG_SIZE}B"
+echo "concurrency: $CONCURRENCY"
+echo "output:      $OUTPUT"
+echo ""
+
+# Build the server and workload binary in release mode.
+echo "building release binaries..."
+cargo build --release --bin fila-server --bin profile-workload 2>&1 | tail -1
+
+# Check that cargo-flamegraph is installed.
+if ! command -v cargo-flamegraph &>/dev/null && ! command -v flamegraph &>/dev/null; then
+    echo "error: cargo-flamegraph not found"
+    echo "install it with: cargo install flamegraph"
+    exit 1
+fi
+
+# Set environment variables for the workload binary.
+export PROFILE_WORKLOAD="$WORKLOAD"
+export PROFILE_DURATION="$DURATION"
+export PROFILE_MSG_SIZE="$MSG_SIZE"
+export PROFILE_CONCURRENCY="$CONCURRENCY"
+
+if [[ "$HEAP" == "true" ]]; then
+    echo ""
+    echo "heap profiling: running with DHAT..."
+    echo "note: DHAT requires recompilation with dhat feature — this is a placeholder"
+    echo "for now, generating a CPU flamegraph instead"
+    echo ""
+fi
+
+echo "running workload under profiler..."
+echo ""
+
+# Use cargo flamegraph to profile the workload binary.
+# On macOS, this uses DTrace. On Linux, it uses perf.
+cargo flamegraph \
+    --bin profile-workload \
+    --output "$OUTPUT" \
+    --root \
+    -- 2>&1 || {
+    # If --root fails (common on macOS without SIP disabled), retry without it.
+    echo ""
+    echo "retrying without --root flag..."
+    cargo flamegraph \
+        --bin profile-workload \
+        --output "$OUTPUT" \
+        -- 2>&1
+}
+
+echo ""
+echo "=== flamegraph generated ==="
+echo "output: $OUTPUT"
+echo ""
+
+# Print a summary if the SVG was generated.
+if [[ -f "$OUTPUT" ]]; then
+    SIZE=$(wc -c < "$OUTPUT" | tr -d ' ')
+    echo "SVG size: ${SIZE} bytes"
+
+    # Extract top functions from the SVG (the flamegraph encodes function names).
+    # This is a best-effort summary — flamegraph SVGs contain sample counts in title attributes.
+    echo ""
+    echo "top functions (by sample count):"
+    # Parse title="function_name (N samples, X%)" from the SVG.
+    if command -v perl &>/dev/null; then
+        perl -nle '
+            while (/title="([^"]+)\s+\((\d+)\s+samples?,\s+([\d.]+)%\)"/g) {
+                printf "%6.1f%%  %6d  %s\n", $3, $2, $1;
+            }
+        ' "$OUTPUT" | sort -t'%' -k1 -rn | head -10
+    else
+        echo "(install perl for function summary)"
+    fi
+
+    echo ""
+    echo "open the SVG in a browser for the interactive flamegraph."
+fi


### PR DESCRIPTION
## Summary

- Add `scripts/flamegraph.sh` for generating CPU flamegraphs of configurable Fila workloads (enqueue-only, consume-only, lifecycle, batch-enqueue) using `cargo-flamegraph` (DTrace on macOS, perf on Linux)
- Add `profile-workload` binary in `fila-bench` crate that drives load against an embedded fila-server using the SDK, parameterized via environment variables (workload type, duration, message size, concurrency)
- Add `Makefile` with convenience targets (`make flamegraph`, `make flamegraph-lifecycle`, etc.) wrapping the script with sensible defaults
- Add `docs/profiling.md` documenting prerequisites, usage, and how to interpret flamegraphs (common patterns: wide RocksDB stacks, tonic overhead, tokio scheduling, Lua hooks)
- Add `target/flamegraphs/` to `.gitignore`

## Test plan

- [x] `profile-workload` binary compiles (`cargo check --bin profile-workload`)
- [ ] Run `make flamegraph` on macOS to verify end-to-end SVG generation (requires `cargo install flamegraph`)
- [ ] Verify generated SVG opens in browser with interactive flamegraph

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds flamegraph tooling to profile Fila CPU hotspots across common workloads using `cargo-flamegraph`. Includes a script, Make targets, and a small workload driver to generate interactive SVGs.

- **New Features**
  - `scripts/flamegraph.sh` to profile workloads (enqueue-only, consume-only, lifecycle, batch-enqueue) with duration, message size, and concurrency; DTrace on macOS, `perf` on Linux.
  - `profile-workload` binary in `fila-bench` that runs configurable loads against an embedded or external server via env vars.
  - Make targets: `flamegraph`, `flamegraph-lifecycle`, `flamegraph-consume`, `flamegraph-batch`.
  - `docs/profiling.md` and `.gitignore` entry for `target/flamegraphs/`.

- **Migration**
  - Install `cargo-flamegraph` (and `perf` on Linux).
  - Generate a graph: `make flamegraph` or `./scripts/flamegraph.sh --workload lifecycle --duration 60`.
  - Open the SVG in `target/flamegraphs/`.

<sup>Written for commit 78b5b6c6babc937251c961d4d607ebafe6776f7d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- bench-results-start -->
## Benchmark Results (median of 3 runs, no baseline yet)

**Commit:** `69207df`  
**Time:** 2026-03-24T14:35:58Z

| Benchmark | Value | Unit |
|---|---:|---|
| compaction_active_enqueue_max | 42.015 | ms |
| compaction_active_enqueue_p50 | 0.694 | ms |
| compaction_active_enqueue_p95 | 0.771 | ms |
| compaction_active_enqueue_p99 | 0.845 | ms |
| compaction_active_enqueue_p99_9 | 1.371 | ms |
| compaction_active_enqueue_p99_99 | 41.343 | ms |
| compaction_idle_enqueue_max | 41.791 | ms |
| compaction_idle_enqueue_p50 | 0.308 | ms |
| compaction_idle_enqueue_p95 | 0.365 | ms |
| compaction_idle_enqueue_p99 | 0.418 | ms |
| compaction_idle_enqueue_p99_9 | 0.979 | ms |
| compaction_idle_enqueue_p99_99 | 41.311 | ms |
| compaction_p99_delta | 0.416 | ms |
| consumer_concurrency_100_throughput | 1700.3333333333333 | msg/s |
| consumer_concurrency_10_throughput | 1250.0 | msg/s |
| consumer_concurrency_1_throughput | 49.0 | msg/s |
| e2e_latency_light_max | 42.911 | ms |
| e2e_latency_light_p50 | 41.439 | ms |
| e2e_latency_light_p95 | 41.663 | ms |
| e2e_latency_light_p99 | 41.823 | ms |
| e2e_latency_light_p99_9 | 42.431 | ms |
| e2e_latency_light_p99_99 | 42.911 | ms |
| enqueue_throughput_1kb | 3119.546411272059 | msg/s |
| enqueue_throughput_1kb_mbps | 3.04643204225787 | MB/s |
| equal_weight_fairness_jains_index | 1.0 | index |
| equal_weight_fairness_max_deviation | 0.0 | % deviation |
| equal_weight_fairness_tenant-1 | 0.0 | % deviation |
| equal_weight_fairness_tenant-2 | 0.0 | % deviation |
| equal_weight_fairness_tenant-3 | 0.0 | % deviation |
| equal_weight_fairness_tenant-4 | 0.0 | % deviation |
| equal_weight_fairness_tenant-5 | 0.0 | % deviation |
| fairness_accuracy_jains_index | 0.999998162209392 | index |
| fairness_accuracy_max_deviation | 0.1999999999999988 | % deviation |
| fairness_accuracy_tenant-1 | 0.1999999999999988 | % deviation |
| fairness_accuracy_tenant-2 | 0.1999999999999988 | % deviation |
| fairness_accuracy_tenant-3 | 0.099999999999989 | % deviation |
| fairness_accuracy_tenant-4 | 0.099999999999989 | % deviation |
| fairness_accuracy_tenant-5 | 0.099999999999989 | % deviation |
| fairness_overhead_fair_throughput | 1123.9887885864966 | msg/s |
| fairness_overhead_fifo_throughput | 1151.757806065025 | msg/s |
| fairness_overhead_pct | 2.3685933721548036 | % |
| key_cardinality_10_throughput | 1296.132378377125 | msg/s |
| key_cardinality_10k_throughput | 493.312998902679 | msg/s |
| key_cardinality_1k_throughput | 768.2145804188484 | msg/s |
| lua_on_enqueue_overhead_us | 14.123059532402069 | us |
| lua_throughput_with_hook | 871.5987360043799 | msg/s |
| memory_per_message_overhead | 3012.608 | bytes/msg |
| memory_rss_idle | 334.04296875 | MB |
| memory_rss_loaded_10k | 362.7109375 | MB |
<!-- bench-results-end -->
