### PR TITLE
feat: add batch benchmark scenarios

### DIFF
--- a/crates/fila-bench/benches/system.rs
+++ b/crates/fila-bench/benches/system.rs
@@ -1,6 +1,6 @@
 use fila_bench::benchmarks::{
-    compaction, failure_paths, fairness, latency, lua, memory, open_loop, scaling, subsystem,
-    throughput,
+    batch, compaction, failure_paths, fairness, latency, lua, memory, open_loop, scaling,
+    subsystem, throughput,
 };
 use fila_bench::report::BenchReport;
 use fila_bench::server::BenchServer;
@@ -185,6 +185,49 @@ async fn run_benchmarks() {
     } else {
         eprintln!(
             "[S1-S5] Subsystem benchmarks (skipped — set FILA_BENCH_SUBSYSTEM=1 to enable)"
+        );
+    }
+
+    // Batch benchmarks (gated — requires batch API support)
+    if std::env::var("FILA_BENCH_BATCH").is_ok() {
+        eprintln!("[B1] BatchEnqueue throughput (batch sizes 1-500)...");
+        let results = batch::bench_batch_enqueue_throughput(&server).await;
+        for r in results {
+            report.add(r);
+        }
+
+        eprintln!("[B2] Batch size scaling (1-1000)...");
+        let results = batch::bench_batch_size_scaling(&server).await;
+        for r in results {
+            report.add(r);
+        }
+
+        eprintln!("[B3] Auto-batching latency (1/10/50 producers)...");
+        let results = batch::bench_auto_batching_latency(&server).await;
+        for r in results {
+            report.add(r);
+        }
+
+        eprintln!("[B4] Batched vs unbatched comparison...");
+        let results = batch::bench_batched_vs_unbatched(&server).await;
+        for r in results {
+            report.add(r);
+        }
+
+        eprintln!("[B5] Delivery batching throughput (1/10/100 consumers)...");
+        let results = batch::bench_delivery_batching_throughput(&server).await;
+        for r in results {
+            report.add(r);
+        }
+
+        eprintln!("[B6] Concurrent producer batching (1/5/10/50 producers)...");
+        let results = batch::bench_concurrent_producer_batching(&server).await;
+        for r in results {
+            report.add(r);
+        }
+    } else {
+        eprintln!(
+            "[B1-B6] Batch benchmarks (skipped — set FILA_BENCH_BATCH=1 to enable)"
         );
     }
 

--- a/crates/fila-bench/src/benchmarks/batch.rs
+++ b/crates/fila-bench/src/benchmarks/batch.rs
@@ -1,0 +1,677 @@
+use crate::measurement::{LatencyHistogram, ThroughputMeter};
+use crate::report::BenchResult;
+use crate::server::{create_queue_cli, BenchServer};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio_stream::StreamExt;
+
+use crate::benchmarks::latency::emit_latency_results;
+
+const PAYLOAD_SIZE: usize = 1024; // 1KB
+const WARMUP_SECS: u64 = 1;
+const MEASURE_SECS: u64 = 3;
+
+fn make_payload() -> Vec<u8> {
+    vec![0x42u8; PAYLOAD_SIZE]
+}
+
+fn make_batch(
+    queue: &str,
+    batch_size: usize,
+    payload: &[u8],
+) -> Vec<fila_sdk::EnqueueMessage> {
+    (0..batch_size)
+        .map(|_| fila_sdk::EnqueueMessage {
+            queue: queue.to_string(),
+            headers: HashMap::new(),
+            payload: payload.to_vec(),
+        })
+        .collect()
+}
+
+/// Count successful results in a batch enqueue response.
+fn count_successes(results: &[fila_sdk::BatchEnqueueResult]) -> u64 {
+    results
+        .iter()
+        .filter(|r| matches!(r, fila_sdk::BatchEnqueueResult::Success(_)))
+        .count() as u64
+}
+
+// ─── Benchmark 1: BatchEnqueue throughput ────────────────────────────────────
+
+/// Measure `BatchEnqueue` RPC throughput at various batch sizes with 1KB messages.
+/// Reports messages/s and batches/s for each batch size.
+pub async fn bench_batch_enqueue_throughput(server: &BenchServer) -> Vec<BenchResult> {
+    let mut results = Vec::new();
+    let batch_sizes: &[usize] = &[1, 10, 50, 100, 500];
+
+    for &batch_size in batch_sizes {
+        let queue = format!("bench-batch-throughput-{batch_size}");
+        create_queue_cli(server.addr(), &queue);
+
+        let client = fila_sdk::FilaClient::connect(server.addr())
+            .await
+            .expect("connect");
+        let payload = make_payload();
+
+        // Warmup
+        let warmup_deadline = tokio::time::Instant::now() + Duration::from_secs(WARMUP_SECS);
+        while tokio::time::Instant::now() < warmup_deadline {
+            let batch = make_batch(&queue, batch_size, &payload);
+            let _ = client.batch_enqueue(batch).await;
+        }
+
+        // Measure
+        let mut msg_meter = ThroughputMeter::start();
+        let mut batch_count: u64 = 0;
+        let measure_deadline = tokio::time::Instant::now() + Duration::from_secs(MEASURE_SECS);
+        while tokio::time::Instant::now() < measure_deadline {
+            let batch = make_batch(&queue, batch_size, &payload);
+            if let Ok(batch_results) = client.batch_enqueue(batch).await {
+                let successes = count_successes(&batch_results);
+                msg_meter.increment_by(successes);
+                batch_count += 1;
+            }
+        }
+
+        let elapsed_secs = msg_meter.elapsed().as_secs_f64();
+        let batches_per_sec = if elapsed_secs > 0.0 {
+            batch_count as f64 / elapsed_secs
+        } else {
+            0.0
+        };
+
+        let meta: HashMap<String, serde_json::Value> = [
+            ("batch_size".to_string(), serde_json::json!(batch_size)),
+            ("payload_size".to_string(), serde_json::json!(PAYLOAD_SIZE)),
+            (
+                "duration_secs".to_string(),
+                serde_json::json!(MEASURE_SECS),
+            ),
+            (
+                "total_messages".to_string(),
+                serde_json::json!(msg_meter.count()),
+            ),
+            (
+                "total_batches".to_string(),
+                serde_json::json!(batch_count),
+            ),
+        ]
+        .into_iter()
+        .collect();
+
+        results.push(BenchResult {
+            name: format!("batch_enqueue_throughput_bs{batch_size}_msgs"),
+            value: msg_meter.msg_per_sec(),
+            unit: "msg/s".to_string(),
+            metadata: meta.clone(),
+        });
+        results.push(BenchResult {
+            name: format!("batch_enqueue_throughput_bs{batch_size}_batches"),
+            value: batches_per_sec,
+            unit: "ops/s".to_string(),
+            metadata: meta,
+        });
+    }
+
+    results
+}
+
+// ─── Benchmark 2: Batch size scaling ─────────────────────────────────────────
+
+/// Measure throughput as a function of batch size (1 to 1000) to find diminishing returns.
+/// Produces throughput-vs-batch-size data points.
+pub async fn bench_batch_size_scaling(server: &BenchServer) -> Vec<BenchResult> {
+    let mut results = Vec::new();
+    let batch_sizes: &[usize] = &[1, 5, 10, 25, 50, 100, 250, 500, 1000];
+
+    for &batch_size in batch_sizes {
+        let queue = format!("bench-batch-scaling-{batch_size}");
+        create_queue_cli(server.addr(), &queue);
+
+        let client = fila_sdk::FilaClient::connect(server.addr())
+            .await
+            .expect("connect");
+        let payload = make_payload();
+
+        // Warmup
+        let warmup_deadline = tokio::time::Instant::now() + Duration::from_secs(WARMUP_SECS);
+        while tokio::time::Instant::now() < warmup_deadline {
+            let batch = make_batch(&queue, batch_size, &payload);
+            let _ = client.batch_enqueue(batch).await;
+        }
+
+        // Measure
+        let mut meter = ThroughputMeter::start();
+        let measure_deadline = tokio::time::Instant::now() + Duration::from_secs(MEASURE_SECS);
+        while tokio::time::Instant::now() < measure_deadline {
+            let batch = make_batch(&queue, batch_size, &payload);
+            if let Ok(batch_results) = client.batch_enqueue(batch).await {
+                meter.increment_by(count_successes(&batch_results));
+            }
+        }
+
+        results.push(BenchResult {
+            name: format!("batch_scaling_bs{batch_size}_throughput"),
+            value: meter.msg_per_sec(),
+            unit: "msg/s".to_string(),
+            metadata: [
+                ("batch_size".to_string(), serde_json::json!(batch_size)),
+                ("payload_size".to_string(), serde_json::json!(PAYLOAD_SIZE)),
+                (
+                    "total_messages".to_string(),
+                    serde_json::json!(meter.count()),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        });
+    }
+
+    results
+}
+
+// ─── Benchmark 3: Auto-batching latency ─────────────────────────────────────
+
+/// Measure end-to-end latency (enqueue to consume) with client-side batching
+/// at various concurrency levels (1, 10, 50 producers).
+///
+/// Simulates auto-batching by accumulating messages in a buffer and flushing
+/// via `batch_enqueue` when the buffer reaches `batch_size`. Reports p50/p99 latency.
+pub async fn bench_auto_batching_latency(server: &BenchServer) -> Vec<BenchResult> {
+    let mut results = Vec::new();
+    let concurrency_levels: &[usize] = &[1, 10, 50];
+    let batch_size: usize = 50;
+
+    for &producer_count in concurrency_levels {
+        let queue = format!("bench-autobatch-latency-{producer_count}");
+        create_queue_cli(server.addr(), &queue);
+
+        let client = fila_sdk::FilaClient::connect(server.addr())
+            .await
+            .expect("connect");
+        let payload = make_payload();
+
+        // Start a consumer to drain messages and record latencies
+        let mut histogram = LatencyHistogram::new();
+        let stop = Arc::new(AtomicBool::new(false));
+        let total_produced = Arc::new(AtomicU64::new(0));
+
+        // Phase 1: Run producers using batch_enqueue with accumulation
+        let producer_stop = stop.clone();
+        let mut producer_handles = Vec::new();
+        for _ in 0..producer_count {
+            let pc = fila_sdk::FilaClient::connect(server.addr())
+                .await
+                .expect("connect producer");
+            let pq = queue.clone();
+            let pp = payload.clone();
+            let ps = producer_stop.clone();
+            let tp = total_produced.clone();
+
+            producer_handles.push(tokio::spawn(async move {
+                while !ps.load(Ordering::Relaxed) {
+                    let batch = make_batch(&pq, batch_size, &pp);
+                    if let Ok(batch_results) = pc.batch_enqueue(batch).await {
+                        tp.fetch_add(count_successes(&batch_results), Ordering::Relaxed);
+                    }
+                }
+            }));
+        }
+
+        // Let producers run briefly to fill the queue
+        tokio::time::sleep(Duration::from_secs(WARMUP_SECS)).await;
+
+        // Phase 2: Measure sequential enqueue-consume round-trip latency
+        // Drain existing messages first
+        {
+            let mut drain = client.consume(&queue).await.expect("consume drain");
+            let drain_deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+            loop {
+                let next = tokio::time::timeout(Duration::from_millis(200), drain.next()).await;
+                match next {
+                    Ok(Some(Ok(msg))) => {
+                        let _ = client.ack(&queue, &msg.id).await;
+                    }
+                    _ => break,
+                }
+                if tokio::time::Instant::now() > drain_deadline {
+                    break;
+                }
+            }
+            drop(drain);
+        }
+
+        // Stop background producers
+        stop.store(true, Ordering::Relaxed);
+        for h in producer_handles {
+            let _ = h.await;
+        }
+
+        // Now measure latency: batch-enqueue then consume each message
+        let mut stream = client.consume(&queue).await.expect("consume stream");
+        let measure_start = Instant::now();
+        let measure_duration = Duration::from_secs(MEASURE_SECS);
+
+        while measure_start.elapsed() < measure_duration {
+            let sample_start = Instant::now();
+            let batch = make_batch(&queue, batch_size, &payload);
+            let enqueue_result = client.batch_enqueue(batch).await;
+            let Ok(batch_results) = enqueue_result else {
+                continue;
+            };
+
+            let expected = count_successes(&batch_results) as usize;
+            let mut received = 0;
+            let batch_timeout = Duration::from_secs(5);
+            let batch_deadline = tokio::time::Instant::now() + batch_timeout;
+
+            while received < expected && tokio::time::Instant::now() < batch_deadline {
+                let next = tokio::time::timeout(Duration::from_secs(2), stream.next()).await;
+                match next {
+                    Ok(Some(Ok(msg))) => {
+                        let _ = client.ack(&queue, &msg.id).await;
+                        received += 1;
+                    }
+                    _ => break,
+                }
+            }
+
+            // Record the batch round-trip time
+            if received > 0 {
+                histogram.record(sample_start.elapsed());
+            }
+        }
+
+        drop(stream);
+
+        let meta: HashMap<String, serde_json::Value> = [
+            (
+                "producer_count".to_string(),
+                serde_json::json!(producer_count),
+            ),
+            ("batch_size".to_string(), serde_json::json!(batch_size)),
+        ]
+        .into_iter()
+        .collect();
+
+        results.extend(emit_latency_results(
+            &histogram,
+            "auto_batching_latency",
+            &format!("{producer_count}p"),
+            &meta,
+        ));
+    }
+
+    results
+}
+
+// ─── Benchmark 4: Batched vs unbatched comparison ────────────────────────────
+
+/// Run identical workloads with unbatched enqueue, explicit batch_enqueue,
+/// and simulated auto-batching (accumulate + flush), producing a comparison.
+pub async fn bench_batched_vs_unbatched(server: &BenchServer) -> Vec<BenchResult> {
+    let mut results = Vec::new();
+    let payload = make_payload();
+    let message_count: u64 = 3000;
+    let batch_size: usize = 100;
+
+    // --- Mode 1: Unbatched (single enqueue per message) ---
+    {
+        let queue = "bench-bvu-unbatched";
+        create_queue_cli(server.addr(), queue);
+        let client = fila_sdk::FilaClient::connect(server.addr())
+            .await
+            .expect("connect");
+        let headers: HashMap<String, String> = HashMap::new();
+
+        // Warmup
+        for _ in 0..100 {
+            let _ = client
+                .enqueue(queue, headers.clone(), payload.clone())
+                .await;
+        }
+
+        let mut meter = ThroughputMeter::start();
+        for _ in 0..message_count {
+            if client
+                .enqueue(queue, headers.clone(), payload.clone())
+                .await
+                .is_ok()
+            {
+                meter.increment();
+            }
+        }
+
+        results.push(BenchResult {
+            name: "batched_vs_unbatched_single_throughput".to_string(),
+            value: meter.msg_per_sec(),
+            unit: "msg/s".to_string(),
+            metadata: [
+                ("mode".to_string(), serde_json::json!("unbatched")),
+                (
+                    "message_count".to_string(),
+                    serde_json::json!(message_count),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        });
+    }
+
+    // --- Mode 2: Explicit batch_enqueue ---
+    {
+        let queue = "bench-bvu-explicit-batch";
+        create_queue_cli(server.addr(), queue);
+        let client = fila_sdk::FilaClient::connect(server.addr())
+            .await
+            .expect("connect");
+
+        // Warmup
+        let warmup_batch = make_batch(queue, batch_size, &payload);
+        let _ = client.batch_enqueue(warmup_batch).await;
+
+        let mut meter = ThroughputMeter::start();
+        let full_batches = message_count as usize / batch_size;
+        let remainder = message_count as usize % batch_size;
+
+        for _ in 0..full_batches {
+            let batch = make_batch(queue, batch_size, &payload);
+            if let Ok(batch_results) = client.batch_enqueue(batch).await {
+                meter.increment_by(count_successes(&batch_results));
+            }
+        }
+        if remainder > 0 {
+            let batch = make_batch(queue, remainder, &payload);
+            if let Ok(batch_results) = client.batch_enqueue(batch).await {
+                meter.increment_by(count_successes(&batch_results));
+            }
+        }
+
+        results.push(BenchResult {
+            name: "batched_vs_unbatched_explicit_batch_throughput".to_string(),
+            value: meter.msg_per_sec(),
+            unit: "msg/s".to_string(),
+            metadata: [
+                ("mode".to_string(), serde_json::json!("explicit_batch")),
+                ("batch_size".to_string(), serde_json::json!(batch_size)),
+                (
+                    "message_count".to_string(),
+                    serde_json::json!(message_count),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        });
+    }
+
+    // --- Mode 3: Simulated auto-batching (accumulate + flush with linger) ---
+    {
+        let queue = "bench-bvu-auto-batch";
+        create_queue_cli(server.addr(), queue);
+        let client = fila_sdk::FilaClient::connect(server.addr())
+            .await
+            .expect("connect");
+        let headers: HashMap<String, String> = HashMap::new();
+
+        // Warmup
+        for _ in 0..100 {
+            let _ = client
+                .enqueue(queue, headers.clone(), payload.clone())
+                .await;
+        }
+
+        // Simulate auto-batching: accumulate messages, flush when batch_size reached
+        let mut meter = ThroughputMeter::start();
+        let mut buffer: Vec<fila_sdk::EnqueueMessage> = Vec::with_capacity(batch_size);
+        let mut produced: u64 = 0;
+
+        while produced < message_count {
+            buffer.push(fila_sdk::EnqueueMessage {
+                queue: queue.to_string(),
+                headers: HashMap::new(),
+                payload: payload.clone(),
+            });
+            produced += 1;
+
+            if buffer.len() >= batch_size || produced == message_count {
+                let batch = std::mem::take(&mut buffer);
+                if let Ok(batch_results) = client.batch_enqueue(batch).await {
+                    meter.increment_by(count_successes(&batch_results));
+                }
+            }
+        }
+
+        results.push(BenchResult {
+            name: "batched_vs_unbatched_auto_batch_throughput".to_string(),
+            value: meter.msg_per_sec(),
+            unit: "msg/s".to_string(),
+            metadata: [
+                ("mode".to_string(), serde_json::json!("auto_batch")),
+                ("batch_size".to_string(), serde_json::json!(batch_size)),
+                (
+                    "message_count".to_string(),
+                    serde_json::json!(message_count),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        });
+    }
+
+    // --- Compute speedup ratios ---
+    let unbatched = results
+        .iter()
+        .find(|r| r.name == "batched_vs_unbatched_single_throughput")
+        .map(|r| r.value)
+        .unwrap_or(1.0);
+
+    let mut speedups = Vec::new();
+    for r in &results {
+        if r.name != "batched_vs_unbatched_single_throughput" && unbatched > 0.0 {
+            let speedup = r.value / unbatched;
+            let mode = r
+                .metadata
+                .get("mode")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+            speedups.push(BenchResult {
+                name: format!("batched_vs_unbatched_{mode}_speedup"),
+                value: speedup,
+                unit: "x".to_string(),
+                metadata: [("vs_baseline".to_string(), serde_json::json!("unbatched"))]
+                    .into_iter()
+                    .collect(),
+            });
+        }
+    }
+    results.extend(speedups);
+
+    results
+}
+
+// ─── Benchmark 5: Delivery batching throughput ───────────────────────────────
+
+/// Measure consumer throughput with varying consumer counts (1, 10, 100).
+/// Pre-loads messages via batch_enqueue, then measures consume throughput.
+pub async fn bench_delivery_batching_throughput(server: &BenchServer) -> Vec<BenchResult> {
+    let mut results = Vec::new();
+    let consumer_counts: &[u32] = &[1, 10, 100];
+    let pre_load: u64 = 10_000;
+    let batch_size: usize = 100;
+    let payload = make_payload();
+
+    for &consumer_count in consumer_counts {
+        let queue = format!("bench-delivery-batch-{consumer_count}");
+        create_queue_cli(server.addr(), &queue);
+
+        let client = fila_sdk::FilaClient::connect(server.addr())
+            .await
+            .expect("connect");
+
+        // Pre-load messages via batch_enqueue
+        let mut loaded: u64 = 0;
+        while loaded < pre_load {
+            let remaining = (pre_load - loaded) as usize;
+            let this_batch = remaining.min(batch_size);
+            let batch = make_batch(&queue, this_batch, &payload);
+            if let Ok(batch_results) = client.batch_enqueue(batch).await {
+                loaded += count_successes(&batch_results);
+            }
+        }
+
+        // Spawn consumers
+        let stop = Arc::new(AtomicBool::new(false));
+        let total_consumed = Arc::new(AtomicU64::new(0));
+        let mut handles = Vec::new();
+
+        for _ in 0..consumer_count {
+            let c = fila_sdk::FilaClient::connect(server.addr())
+                .await
+                .expect("connect consumer");
+            let q = queue.clone();
+            let s = stop.clone();
+            let tc = total_consumed.clone();
+            handles.push(tokio::spawn(async move {
+                if let Ok(mut stream) = c.consume(&q).await {
+                    while !s.load(Ordering::Relaxed) {
+                        match stream.next().await {
+                            Some(Ok(msg)) => {
+                                if c.ack(&q, &msg.id).await.is_ok() {
+                                    tc.fetch_add(1, Ordering::Relaxed);
+                                }
+                            }
+                            _ => break,
+                        }
+                    }
+                }
+            }));
+        }
+
+        // Also keep producing so consumers don't starve
+        let producer_stop = stop.clone();
+        let producer_client = fila_sdk::FilaClient::connect(server.addr())
+            .await
+            .expect("connect producer");
+        let producer_queue = queue.clone();
+        let producer_payload = payload.clone();
+        let producer = tokio::spawn(async move {
+            while !producer_stop.load(Ordering::Relaxed) {
+                let batch = make_batch(&producer_queue, batch_size, &producer_payload);
+                let _ = producer_client.batch_enqueue(batch).await;
+            }
+        });
+
+        // Measure
+        let before = total_consumed.load(Ordering::Relaxed);
+        tokio::time::sleep(Duration::from_secs(MEASURE_SECS)).await;
+        let after = total_consumed.load(Ordering::Relaxed);
+
+        stop.store(true, Ordering::Relaxed);
+        producer.abort();
+        for h in handles {
+            h.abort();
+        }
+
+        let consumed = after - before;
+        let throughput = consumed as f64 / MEASURE_SECS as f64;
+
+        results.push(BenchResult {
+            name: format!("delivery_batching_{consumer_count}c_throughput"),
+            value: throughput,
+            unit: "msg/s".to_string(),
+            metadata: [
+                (
+                    "consumer_count".to_string(),
+                    serde_json::json!(consumer_count),
+                ),
+                ("batch_size".to_string(), serde_json::json!(batch_size)),
+            ]
+            .into_iter()
+            .collect(),
+        });
+    }
+
+    results
+}
+
+// ─── Benchmark 6: Concurrent producer batching ──────────────────────────────
+
+/// Measure throughput with 1, 5, 10, 50 concurrent producers using batch_enqueue.
+pub async fn bench_concurrent_producer_batching(server: &BenchServer) -> Vec<BenchResult> {
+    let mut results = Vec::new();
+    let producer_counts: &[usize] = &[1, 5, 10, 50];
+    let batch_size: usize = 100;
+    let payload = make_payload();
+
+    for &producer_count in producer_counts {
+        let queue = format!("bench-concurrent-batch-{producer_count}");
+        create_queue_cli(server.addr(), &queue);
+
+        // Warmup with a single client
+        let warmup_client = fila_sdk::FilaClient::connect(server.addr())
+            .await
+            .expect("connect warmup");
+        let warmup_deadline = tokio::time::Instant::now() + Duration::from_secs(WARMUP_SECS);
+        while tokio::time::Instant::now() < warmup_deadline {
+            let batch = make_batch(&queue, batch_size, &payload);
+            let _ = warmup_client.batch_enqueue(batch).await;
+        }
+        drop(warmup_client);
+
+        // Spawn producers
+        let stop = Arc::new(AtomicBool::new(false));
+        let total_messages = Arc::new(AtomicU64::new(0));
+        let mut handles = Vec::new();
+
+        for _ in 0..producer_count {
+            let pc = fila_sdk::FilaClient::connect(server.addr())
+                .await
+                .expect("connect producer");
+            let pq = queue.clone();
+            let pp = payload.clone();
+            let ps = stop.clone();
+            let tm = total_messages.clone();
+            handles.push(tokio::spawn(async move {
+                while !ps.load(Ordering::Relaxed) {
+                    let batch = make_batch(&pq, batch_size, &pp);
+                    if let Ok(batch_results) = pc.batch_enqueue(batch).await {
+                        tm.fetch_add(count_successes(&batch_results), Ordering::Relaxed);
+                    }
+                }
+            }));
+        }
+
+        // Measure
+        let before = total_messages.load(Ordering::Relaxed);
+        tokio::time::sleep(Duration::from_secs(MEASURE_SECS)).await;
+        let after = total_messages.load(Ordering::Relaxed);
+
+        stop.store(true, Ordering::Relaxed);
+        for h in handles {
+            h.abort();
+        }
+
+        let produced = after - before;
+        let throughput = produced as f64 / MEASURE_SECS as f64;
+
+        results.push(BenchResult {
+            name: format!("concurrent_batch_{producer_count}p_throughput"),
+            value: throughput,
+            unit: "msg/s".to_string(),
+            metadata: [
+                (
+                    "producer_count".to_string(),
+                    serde_json::json!(producer_count),
+                ),
+                ("batch_size".to_string(), serde_json::json!(batch_size)),
+            ]
+            .into_iter()
+            .collect(),
+        });
+    }
+
+    results
+}

--- a/crates/fila-bench/src/benchmarks/mod.rs
+++ b/crates/fila-bench/src/benchmarks/mod.rs
@@ -1,3 +1,4 @@
+pub mod batch;
 pub mod compaction;
 pub mod failure_paths;
 pub mod fairness;

--- a/crates/fila-bench/src/compare.rs
+++ b/crates/fila-bench/src/compare.rs
@@ -37,12 +37,13 @@ fn higher_is_better(result: &BenchResult) -> bool {
     let name = result.name.as_str();
     let unit = result.unit.as_str();
 
-    // Throughput metrics: higher is better
+    // Throughput and speedup metrics: higher is better
     if unit == "msg/s"
         || unit == "MB/s"
         || unit == "ops/s"
         || unit == "sel/s"
         || unit == "exec/s"
+        || unit == "x"
     {
         return true;
     }

--- a/crates/fila-bench/src/report.rs
+++ b/crates/fila-bench/src/report.rs
@@ -120,12 +120,13 @@ impl BenchReport {
 /// operates on raw name/unit strings so it can be used from the report module
 /// without importing compare internals.
 fn gab_higher_is_better(name: &str, unit: &str) -> bool {
-    // Throughput metrics: higher is better
+    // Throughput and speedup metrics: higher is better
     if unit == "msg/s"
         || unit == "MB/s"
         || unit == "ops/s"
         || unit == "sel/s"
         || unit == "exec/s"
+        || unit == "x"
     {
         return true;
     }
@@ -259,6 +260,7 @@ mod tests {
         assert!(gab_higher_is_better("anything", "ops/s"));
         assert!(gab_higher_is_better("anything", "sel/s"));
         assert!(gab_higher_is_better("anything", "exec/s"));
+        assert!(gab_higher_is_better("anything", "x"));
         assert!(gab_higher_is_better("custom_throughput_metric", "widgets"));
 
         // Lower is better

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -102,6 +102,87 @@ Memory usage is dominated by the RocksDB buffer pool, not message count.
 
 Compaction has no measurable negative impact on tail latency in single-node benchmarks.
 
+## Batch benchmarks
+
+Batch benchmarks measure throughput and latency of the `BatchEnqueue` RPC and compare it against single-message enqueue. These benchmarks are gated behind `FILA_BENCH_BATCH=1` because they exercise batch-specific code paths and take additional time.
+
+Enable with `FILA_BENCH_BATCH=1`:
+
+```bash
+FILA_BENCH_BATCH=1 cargo bench -p fila-bench --bench system
+```
+
+### BatchEnqueue throughput
+
+Measures `BatchEnqueue` RPC throughput at various batch sizes with 1KB messages. Reports both messages/s and batches/s.
+
+| Batch size | Metric |
+|-----------:|--------|
+| 1 | msg/s, batches/s |
+| 10 | msg/s, batches/s |
+| 50 | msg/s, batches/s |
+| 100 | msg/s, batches/s |
+| 500 | msg/s, batches/s |
+
+### Batch size scaling
+
+Measures throughput as a function of batch size (1 to 1000) to identify the point of diminishing returns.
+
+| Batch size | Metric |
+|-----------:|--------|
+| 1 | msg/s |
+| 5 | msg/s |
+| 10 | msg/s |
+| 25 | msg/s |
+| 50 | msg/s |
+| 100 | msg/s |
+| 250 | msg/s |
+| 500 | msg/s |
+| 1000 | msg/s |
+
+### Auto-batching latency
+
+Measures end-to-end latency (batch enqueue to consume) at various producer concurrency levels. Simulates client-side auto-batching by accumulating messages and flushing via `batch_enqueue` at batch size 50.
+
+| Producers | Metrics |
+|----------:|---------|
+| 1 | p50, p95, p99, p99.9, p99.99, max |
+| 10 | p50, p95, p99, p99.9, p99.99, max |
+| 50 | p50, p95, p99, p99.9, p99.99, max |
+
+### Batched vs unbatched comparison
+
+Runs identical workloads (3,000 messages) with three approaches and reports throughput and speedup ratios.
+
+| Mode | Description |
+|------|-------------|
+| **Unbatched** | Single `enqueue()` per message |
+| **Explicit batch** | `batch_enqueue()` with batch size 100 |
+| **Auto-batch** | Client-side accumulation, flush at batch size 100 |
+
+Speedup ratios are computed relative to the unbatched baseline.
+
+### Delivery batching throughput
+
+Measures consumer throughput with varying concurrent consumer counts. Messages are pre-loaded and continuously produced via `batch_enqueue`.
+
+| Consumers | Metric |
+|----------:|--------|
+| 1 | msg/s |
+| 10 | msg/s |
+| 100 | msg/s |
+
+### Concurrent producer batching
+
+Measures aggregate throughput with multiple concurrent producers all using `batch_enqueue` (batch size 100).
+
+| Producers | Metric |
+|----------:|--------|
+| 1 | msg/s |
+| 5 | msg/s |
+| 10 | msg/s |
+| 50 | msg/s |
+
 ## Subsystem benchmarks
 
 Subsystem benchmarks isolate and measure each internal component independently, bypassing the full server stack. This helps identify where time is spent and which component dominates in different workloads.


### PR DESCRIPTION
## Summary

- Adds 6 batch-specific benchmark scenarios to `fila-bench`, gated behind `FILA_BENCH_BATCH=1`
- Benchmarks cover: batch enqueue throughput (various batch sizes), batch size scaling curve, auto-batching latency under concurrency, batched vs unbatched comparison with speedup ratios, delivery batching with varying consumer counts, and concurrent producer batching
- Adds `"x"` (speedup ratio) unit to GAB polarity as higher-is-better in both `report.rs` and `compare.rs`
- Documents all batch benchmarks in `docs/benchmarks.md`

## Test plan

- [x] `cargo check -p fila-bench` compiles cleanly
- [x] `cargo test -p fila-bench` passes all 24 existing tests (no regressions)
- [ ] Run `FILA_BENCH_BATCH=1 cargo bench -p fila-bench --bench system` to verify benchmarks execute end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds six batch benchmark scenarios to `fila-bench`, gated by `FILA_BENCH_BATCH=1`, to measure batch enqueue throughput, latency, and scaling. Also treats speedup ratios (`x`) as higher-is-better in reports and comparisons, and documents the new benchmarks.

- **New Features**
  - Six batch benches: enqueue throughput (1–500, reports msg/s and batches/s), batch size scaling (1–1000), auto-batching latency (1/10/50 producers), batched vs unbatched with speedup ratios, delivery batching throughput (1/10/100 consumers), and concurrent producer batching (1/5/10/50 producers).
  - Integrated into the `system` bench; skipped unless `FILA_BENCH_BATCH` is set; reporting updated for `x` speedups; docs updated in `docs/benchmarks.md`.

- **Migration**
  - To run: `FILA_BENCH_BATCH=1 cargo bench -p fila-bench --bench system`

<sup>Written for commit 19e861a80513c2c37dede84701349a66c1e4b9cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- bench-results-start -->
## Benchmark Results (vs main baseline)

**Baseline commit:** `d47fbfa`  **PR commit:** `61a5067`  **Threshold:** 10%

| Benchmark | Baseline | Current | Change | Unit | |
|---|---:|---:|---:|---|:---:|
| compaction_active_enqueue_max | 41.50 | 41.44 | -0.2% | ms |  |
| compaction_active_enqueue_p50 | 0.69 | 0.72 | +4.6% | ms |  |
| compaction_active_enqueue_p95 | 0.76 | 0.78 | +3.2% | ms |  |
| compaction_active_enqueue_p99 | 0.83 | 0.87 | +3.8% | ms |  |
| compaction_active_enqueue_p99_9 | 1.62 | 1.51 | -6.8% | ms |  |
| compaction_active_enqueue_p99_99 | 41.31 | 41.22 | -0.2% | ms |  |
| compaction_idle_enqueue_max | 41.57 | 42.27 | +1.7% | ms |  |
| compaction_idle_enqueue_p50 | 0.29 | 0.37 | +28.2% | ms | 🔴 |
| compaction_idle_enqueue_p95 | 0.35 | 0.45 | +27.4% | ms | 🔴 |
| compaction_idle_enqueue_p99 | 0.41 | 0.49 | +19.7% | ms | 🔴 |
| compaction_idle_enqueue_p99_9 | 1.11 | 0.88 | -20.8% | ms | 🟢 |
| compaction_idle_enqueue_p99_99 | 41.25 | 41.25 | +0.0% | ms |  |
| compaction_p99_delta | 0.42 | 0.37 | -12.3% | ms | 🟢 |
| consumer_concurrency_100_throughput | 1830.00 | 1467.33 | -19.8% | msg/s | 🔴 |
| consumer_concurrency_10_throughput | 1262.00 | 1172.33 | -7.1% | msg/s |  |
| consumer_concurrency_1_throughput | 49.67 | 73.00 | +47.0% | msg/s | 🟢 |
| e2e_latency_light_max | 43.30 | 42.59 | -1.6% | ms |  |
| e2e_latency_light_p50 | 41.41 | 41.28 | -0.3% | ms |  |
| e2e_latency_light_p95 | 41.57 | 41.57 | +0.0% | ms |  |
| e2e_latency_light_p99 | 41.66 | 41.63 | -0.1% | ms |  |
| e2e_latency_light_p99_9 | 42.40 | 42.30 | -0.2% | ms |  |
| e2e_latency_light_p99_99 | 43.30 | 42.59 | -1.6% | ms |  |
| enqueue_throughput_1kb | 3206.24 | 2537.89 | -20.8% | msg/s | 🔴 |
| enqueue_throughput_1kb_mbps | 3.13 | 2.48 | -20.8% | MB/s | 🔴 |
| equal_weight_fairness_jains_index | 1.00 | 1.00 | +0.0% | index |  |
| equal_weight_fairness_max_deviation | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-1 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-2 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-3 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-4 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-5 | 0.00 | 0.00 | n/a | % deviation |  |
| fairness_accuracy_jains_index | 1.00 | 1.00 | +0.0% | index |  |
| fairness_accuracy_max_deviation | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-1 | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-2 | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-3 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-4 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-5 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_overhead_fair_throughput | 1118.52 | 1077.40 | -3.7% | msg/s |  |
| fairness_overhead_fifo_throughput | 1140.02 | 1118.18 | -1.9% | msg/s |  |
| fairness_overhead_pct | 2.35 | 3.08 | +30.9% | % | 🔴 |
| key_cardinality_10_throughput | 1325.23 | 1278.83 | -3.5% | msg/s |  |
| key_cardinality_10k_throughput | 511.16 | 498.11 | -2.6% | msg/s |  |
| key_cardinality_1k_throughput | 792.99 | 776.88 | -2.0% | msg/s |  |
| lua_on_enqueue_overhead_us | 12.55 | 18.25 | +45.5% | us | 🔴 |
| lua_throughput_with_hook | 855.14 | 897.85 | +5.0% | msg/s |  |
| memory_per_message_overhead | 3019.98 | 2912.67 | -3.6% | bytes/msg |  |
| memory_rss_idle | 337.00 | 335.07 | -0.6% | MB |  |
| memory_rss_loaded_10k | 365.98 | 362.99 | -0.8% | MB |  |

**Summary:** 8 regressed, 3 improved, 38 unchanged

> ⚠️ **Performance regression detected** — 8 metric(s) exceeded the 10% threshold
<!-- bench-results-end -->

