### PR TITLE
feat: 30.4 — unified enqueue handler (throughput fix)

### DIFF
--- a/_bmad-output/implementation-artifacts/epic-execution-state.yaml
+++ b/_bmad-output/implementation-artifacts/epic-execution-state.yaml
@@ -21,13 +21,13 @@ stories:
     status: completed
     currentPhase: "pr-complete"
     branch: "feat/30.3-scheduler-enqueue-batch-refactor"
-    pr: null
+    pr: 114
     dependsOn: ["30.2"]
   - id: "30.4"
     title: "Unified Enqueue Handler — Throughput Fix"
-    status: pending
-    currentPhase: ""
-    branch: ""
+    status: completed
+    currentPhase: "pr-complete"
+    branch: "feat/30.4-unified-enqueue-handler"
     pr: null
     dependsOn: ["30.3"]
   - id: "30.5"

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -277,7 +277,7 @@ development_status:
   30-1-api-surface-unification: done
   30-2-external-sdk-unification: done
   30-3-scheduler-enqueue-batch-refactor: done
-  30-4-unified-enqueue-handler-throughput-fix: backlog
+  30-4-unified-enqueue-handler-throughput-fix: done
   30-5-profile-checkpoint-post-tier-0: backlog
   30-6-stream-enqueue-batch-within-stream: backlog
   30-7-sdk-adaptive-accumulator: backlog

--- a/_bmad-output/implementation-artifacts/stories/30-4-unified-enqueue-handler.md
+++ b/_bmad-output/implementation-artifacts/stories/30-4-unified-enqueue-handler.md
@@ -1,0 +1,42 @@
+# Story 30.4: Unified Enqueue Handler — Throughput Fix
+
+Status: review
+
+## Story
+
+As a developer,
+I want the unified enqueue handler to submit batches to the scheduler as a single Enqueue command,
+so that the sequential per-message round-trip bottleneck (328 msg/s = 3ms x N) is eliminated.
+
+## Acceptance Criteria
+
+1. Non-cluster enqueue handler submits all messages as a single `SchedulerCommand::Enqueue`
+2. ACL checks performed per-message; passing messages batched into single scheduler command
+3. Cluster mode falls back to per-message processing (documented)
+4. StreamEnqueue continues to process per-stream-write (already batched by stream coalescing)
+5. All existing tests pass
+
+## Tasks / Subtasks
+
+- [x] Task 1: Extract `prepare_enqueue_message` (ACL + Message construction, no scheduler send)
+- [x] Task 2: Rewrite `enqueue()` handler for single-command batch submission
+- [x] Task 3: Merge ACL failures and scheduler results by slot position
+- [x] Task 4: Cluster mode documented as per-message fallback
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.6 (1M context)
+
+### Completion Notes List
+
+- `prepare_enqueue_message` extracted for ACL+construction without scheduler round-trip
+- Non-cluster: single `SchedulerCommand::Enqueue` for all valid messages in the batch
+- Cluster: per-message `ClusterRequest::Enqueue` (Raft consensus per-message, batch optimization future work)
+- StreamEnqueue unchanged — already coalesces via drain loop
+- Result slot merging preserves input order with mixed ACL failures and scheduler results
+
+### File List
+
+- crates/fila-server/src/service.rs

--- a/crates/fila-server/src/service.rs
+++ b/crates/fila-server/src/service.rs
@@ -104,18 +104,17 @@ fn nack_result_from(result: Result<(), Status>) -> NackResult {
     }
 }
 
-/// Process a single enqueue message. Used by the unary and streaming handlers.
-async fn process_enqueue_message(
+/// Validate and construct a Message from a proto EnqueueMessage.
+/// Performs ACL checks but does NOT send to the scheduler.
+fn prepare_enqueue_message(
     caller: &Option<CallerKey>,
-    broker: &Arc<Broker>,
-    cluster: &Option<Arc<ClusterHandle>>,
+    broker: &Broker,
     msg: EnqueueMessage,
-) -> Result<String, Status> {
+) -> Result<Message, Status> {
     if msg.queue.is_empty() {
         return Err(Status::invalid_argument("queue name must not be empty"));
     }
 
-    // ACL check: produce permission on this queue.
     if let Some(ref caller) = caller {
         let permitted = broker
             .check_permission(
@@ -137,11 +136,9 @@ async fn process_enqueue_message(
         .unwrap_or_default()
         .as_nanos() as u64;
 
-    let msg_id = Uuid::now_v7();
-
-    let message = Message {
-        id: msg_id,
-        queue_id: msg.queue.clone(),
+    Ok(Message {
+        id: Uuid::now_v7(),
+        queue_id: msg.queue,
         headers: msg.headers,
         payload: msg.payload,
         fairness_key: "default".to_string(),
@@ -150,12 +147,23 @@ async fn process_enqueue_message(
         attempt_count: 0,
         enqueued_at: now_ns,
         leased_at: None,
-    };
+    })
+}
+
+/// Process a single enqueue message end-to-end (cluster or local).
+/// Used by the streaming handler which processes messages individually.
+async fn process_enqueue_message(
+    caller: &Option<CallerKey>,
+    broker: &Arc<Broker>,
+    cluster: &Option<Arc<ClusterHandle>>,
+    msg: EnqueueMessage,
+) -> Result<String, Status> {
+    let message = prepare_enqueue_message(caller, broker, msg)?;
 
     if let Some(ref cluster) = cluster {
         let result = cluster
             .write_to_queue(
-                &msg.queue,
+                &message.queue_id,
                 ClusterRequest::Enqueue {
                     message: message.clone(),
                 },
@@ -444,11 +452,75 @@ impl FilaService for HotPathService {
 
         tracing::Span::current().record("batch_size", req.messages.len());
 
-        let mut results = Vec::with_capacity(req.messages.len());
-        for msg in req.messages {
-            let result = process_enqueue_message(&caller, &self.broker, &self.cluster, msg).await;
-            results.push(enqueue_result_from(result));
+        // Cluster mode: per-message cluster writes (Raft consensus per-message).
+        // Batch optimization for cluster enqueue is future work.
+        if self.cluster.is_some() {
+            let mut results = Vec::with_capacity(req.messages.len());
+            for msg in req.messages {
+                let result =
+                    process_enqueue_message(&caller, &self.broker, &self.cluster, msg).await;
+                results.push(enqueue_result_from(result));
+            }
+            return Ok(Response::new(EnqueueResponse { results }));
         }
+
+        // Non-cluster: prepare all messages (ACL + construction), then submit
+        // as a single SchedulerCommand::Enqueue. This eliminates the per-message
+        // round-trip bottleneck (328 msg/s = 3ms × N → single round-trip).
+        let msg_count = req.messages.len();
+        let mut valid_messages: Vec<Message> = Vec::with_capacity(msg_count);
+        // Track which input positions had ACL/validation failures (Some = error)
+        // vs which passed and need scheduler results (None = pending).
+        let mut result_slots: Vec<Option<EnqueueResult>> = Vec::with_capacity(msg_count);
+
+        for msg in req.messages {
+            match prepare_enqueue_message(&caller, &self.broker, msg) {
+                Ok(message) => {
+                    valid_messages.push(message);
+                    result_slots.push(None);
+                }
+                Err(status) => {
+                    result_slots.push(Some(enqueue_result_from(Err(status))));
+                }
+            }
+        }
+
+        if valid_messages.is_empty() {
+            // All messages failed validation/ACL
+            return Ok(Response::new(EnqueueResponse {
+                results: result_slots
+                    .into_iter()
+                    .map(|r| r.expect("all slots should be filled"))
+                    .collect(),
+            }));
+        }
+
+        // Single round-trip to the scheduler for all valid messages.
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        self.broker
+            .send_command(SchedulerCommand::Enqueue {
+                messages: valid_messages,
+                reply: reply_tx,
+            })
+            .map_err(IntoStatus::into_status)?;
+
+        let scheduler_results = reply_rx
+            .await
+            .map_err(|_| Status::internal("scheduler reply channel dropped"))?;
+
+        // Merge scheduler results back into the slot positions.
+        let mut sched_iter = scheduler_results.into_iter();
+        let results: Vec<EnqueueResult> = result_slots
+            .into_iter()
+            .map(|slot| match slot {
+                Some(acl_error) => acl_error,
+                None => match sched_iter.next() {
+                    Some(Ok(msg_id)) => enqueue_result_from(Ok(msg_id.to_string())),
+                    Some(Err(e)) => enqueue_result_from(Err(IntoStatus::into_status(e))),
+                    None => enqueue_result_from(Err(Status::internal("missing scheduler result"))),
+                },
+            })
+            .collect();
 
         Ok(Response::new(EnqueueResponse { results }))
     }


### PR DESCRIPTION
## Summary

- Non-cluster enqueue handler submits entire batch as single `SchedulerCommand::Enqueue` — eliminates the per-message round-trip bottleneck (328 msg/s = 3ms × N)
- `prepare_enqueue_message` extracted for ACL + Message construction without scheduler send
- ACL failures and scheduler results merged by slot position (preserves input order)
- Cluster mode: per-message `ClusterRequest::Enqueue` (Raft consensus, documented as future optimization)
- StreamEnqueue unchanged (already coalesces via drain loop)

## Test plan

- [x] All tests pass (`cargo test --workspace`)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Non-cluster enqueue now sends each batch as a single `SchedulerCommand::Enqueue`, removing per-message round trips and improving throughput. Also adds `prepare_enqueue_message` for ACL + message construction and preserves input order when mixing ACL failures with scheduler results.

- **New Features**
  - Non-cluster: submit whole batch in one `SchedulerCommand::Enqueue` (eliminates 3ms × N bottleneck).
  - Added `prepare_enqueue_message` to validate ACLs and build `Message` without scheduler I/O.
  - Merge ACL failures and scheduler replies by slot to preserve input order.
  - Cluster remains per-message via `ClusterRequest::Enqueue` (future optimization); streaming path unchanged.

<sup>Written for commit 40940fd4899dbb0c5dc90b7448273540a6f25c89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- bench-results-start -->
## Benchmark Results (vs main baseline)

**Baseline commit:** `93584a6`  **PR commit:** `9cf2cef`  **Threshold:** 10%

| Benchmark | Baseline | Current | Change | Unit | |
|---|---:|---:|---:|---|:---:|
| compaction_active_enqueue_max | 41.18 | 41.25 | +0.2% | ms |  |
| compaction_active_enqueue_p50 | 0.66 | 0.69 | +4.2% | ms |  |
| compaction_active_enqueue_p95 | 0.70 | 0.73 | +3.6% | ms |  |
| compaction_active_enqueue_p99 | 0.78 | 0.78 | +0.4% | ms |  |
| compaction_active_enqueue_p99_9 | 40.77 | 40.77 | +0.0% | ms |  |
| compaction_active_enqueue_p99_99 | 41.15 | 41.15 | +0.0% | ms |  |
| compaction_idle_enqueue_max | 41.22 | 41.60 | +0.9% | ms |  |
| compaction_idle_enqueue_p50 | 0.31 | 0.33 | +6.4% | ms |  |
| compaction_idle_enqueue_p95 | 0.35 | 0.37 | +5.8% | ms |  |
| compaction_idle_enqueue_p99 | 0.37 | 0.40 | +5.9% | ms |  |
| compaction_idle_enqueue_p99_9 | 40.73 | 40.80 | +0.2% | ms |  |
| compaction_idle_enqueue_p99_99 | 41.15 | 41.18 | +0.1% | ms |  |
| compaction_p99_delta | 0.38 | 0.39 | +2.1% | ms |  |
| consumer_concurrency_100_throughput | 1782.00 | 1758.00 | -1.3% | msg/s |  |
| consumer_concurrency_10_throughput | 1119.00 | 1128.67 | +0.9% | msg/s |  |
| consumer_concurrency_1_throughput | 130.33 | 122.67 | -5.9% | msg/s |  |
| e2e_latency_light_max | 42.53 | 41.66 | -2.0% | ms |  |
| e2e_latency_light_p50 | 40.54 | 40.54 | +0.0% | ms |  |
| e2e_latency_light_p95 | 40.70 | 41.38 | +1.7% | ms |  |
| e2e_latency_light_p99 | 41.41 | 41.44 | +0.1% | ms |  |
| e2e_latency_light_p99_9 | 41.50 | 41.50 | +0.0% | ms |  |
| e2e_latency_light_p99_99 | 42.53 | 41.66 | -2.0% | ms |  |
| enqueue_throughput_1kb | 3486.96 | 2910.12 | -16.5% | msg/s | 🔴 |
| enqueue_throughput_1kb_mbps | 3.41 | 2.84 | -16.5% | MB/s | 🔴 |
| equal_weight_fairness_jains_index | 1.00 | 1.00 | +0.0% | index |  |
| equal_weight_fairness_max_deviation | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-1 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-2 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-3 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-4 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-5 | 0.00 | 0.00 | n/a | % deviation |  |
| fairness_accuracy_jains_index | 1.00 | 1.00 | +0.0% | index |  |
| fairness_accuracy_max_deviation | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-1 | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-2 | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-3 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-4 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-5 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_overhead_fair_throughput | 1103.32 | 1030.80 | -6.6% | msg/s |  |
| fairness_overhead_fifo_throughput | 1106.24 | 1067.50 | -3.5% | msg/s |  |
| fairness_overhead_pct | 0.29 | 3.30 | +1050.0% | % | 🔴 |
| key_cardinality_10_throughput | 1273.29 | 1252.72 | -1.6% | msg/s |  |
| key_cardinality_10k_throughput | 506.56 | 503.33 | -0.6% | msg/s |  |
| key_cardinality_1k_throughput | 778.65 | 767.94 | -1.4% | msg/s |  |
| lua_on_enqueue_overhead_us | 27.41 | 32.89 | +20.0% | us | 🔴 |
| lua_throughput_with_hook | 874.09 | 856.74 | -2.0% | msg/s |  |
| memory_per_message_overhead | 169.16 | 1760.46 | +940.7% | bytes/msg | 🔴 |
| memory_rss_idle | 427.90 | 407.07 | -4.9% | MB |  |
| memory_rss_loaded_10k | 429.99 | 423.66 | -1.5% | MB |  |

**Summary:** 5 regressed, 0 improved, 44 unchanged

> ⚠️ **Performance regression detected** — 5 metric(s) exceeded the 10% threshold
<!-- bench-results-end -->
