### PR TITLE
perf: 32.4 — eliminate message deep-clone in enqueue hot path

### DIFF
--- a/_bmad-output/epic-execution-state.yaml
+++ b/_bmad-output/epic-execution-state.yaml
@@ -25,8 +25,8 @@ stories:
     dependsOn: ["32.1"]
   - id: "32.4"
     title: "Hybrid Envelope — Store-as-Received"
-    status: in-progress
-    currentPhase: "dev"
+    status: completed
+    currentPhase: ""
     branch: "feat/32.4-hybrid-envelope"
     pr: null
     dependsOn: ["32.1"]

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -298,7 +298,7 @@ development_status:
   32-1-profile-baseline: done
   32-2-rocksdb-quick-wins: done
   32-3-string-interning: done
-  32-4-hybrid-envelope-store-as-received: in-progress
+  32-4-hybrid-envelope-store-as-received: review
   32-5-arena-allocation: ready-for-dev
   32-6-plateau-1-profile-checkpoint: ready-for-dev
   epic-32-retrospective: optional


### PR DESCRIPTION
## Summary

- Eliminates `Message::clone()` in `prepare_enqueue()` by extracting small fields before consuming the message by value
- Avoids deep-cloning: headers HashMap, payload Bytes, fairness_key, id, timestamps
- Only queue_id (1 String) and throttle_keys (Vec<String>, typically 0-2 items) are cloned; weight is Copy
- Message is consumed into proto conversion by value instead of clone

## Test plan

- [ ] 396 fila-core tests pass, 20 fila-server tests pass
- [ ] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates deep `Message` cloning in the enqueue hot path to reduce allocations and latency. Supports Linear 32.4 (Hybrid Envelope — Store-as-Received) by consuming the message by value during proto conversion.

- **Refactors**
  - Extract small fields before moving the `Message`.
  - Avoid cloning headers, payload, fairness_key, id, and timestamps.
  - Only `queue_id` and `throttle_keys` are cloned; `weight` is Copy.

<sup>Written for commit 21ecf2d23409a7ddbc9a3ea2b3f8364e19b73547. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- bench-results-start -->
## Benchmark Results (vs main baseline)

**Baseline commit:** `db9015d`  **PR commit:** `bfa0dee`  **Threshold:** 10%

| Benchmark | Baseline | Current | Change | Unit | |
|---|---:|---:|---:|---|:---:|
| compaction_active_enqueue_max | 41.25 | 41.28 | +0.1% | ms |  |
| compaction_active_enqueue_p50 | 0.66 | 0.66 | +0.5% | ms |  |
| compaction_active_enqueue_p95 | 0.69 | 0.74 | +6.6% | ms |  |
| compaction_active_enqueue_p99 | 0.74 | 0.78 | +5.5% | ms |  |
| compaction_active_enqueue_p99_9 | 40.73 | 40.77 | +0.1% | ms |  |
| compaction_active_enqueue_p99_99 | 41.15 | 41.22 | +0.2% | ms |  |
| compaction_idle_enqueue_max | 41.44 | 41.25 | -0.5% | ms |  |
| compaction_idle_enqueue_p50 | 0.31 | 0.29 | -6.4% | ms |  |
| compaction_idle_enqueue_p95 | 0.34 | 0.33 | -3.8% | ms |  |
| compaction_idle_enqueue_p99 | 0.37 | 0.36 | -1.4% | ms |  |
| compaction_idle_enqueue_p99_9 | 40.80 | 40.80 | +0.0% | ms |  |
| compaction_idle_enqueue_p99_99 | 41.15 | 41.22 | +0.2% | ms |  |
| compaction_p99_delta | 0.38 | 0.39 | +4.5% | ms |  |
| consumer_concurrency_100_throughput | 1735.33 | 1639.33 | -5.5% | msg/s |  |
| consumer_concurrency_10_throughput | 1093.00 | 1061.00 | -2.9% | msg/s |  |
| consumer_concurrency_1_throughput | 100.67 | 96.33 | -4.3% | msg/s |  |
| e2e_latency_light_max | 41.63 | 42.43 | +1.9% | ms |  |
| e2e_latency_light_p50 | 40.54 | 40.58 | +0.1% | ms |  |
| e2e_latency_light_p95 | 41.34 | 41.41 | +0.2% | ms |  |
| e2e_latency_light_p99 | 41.44 | 41.44 | +0.0% | ms |  |
| e2e_latency_light_p99_9 | 41.50 | 41.53 | +0.1% | ms |  |
| e2e_latency_light_p99_99 | 41.63 | 42.43 | +1.9% | ms |  |
| enqueue_throughput_1kb | 3140.00 | 3158.91 | +0.6% | msg/s |  |
| enqueue_throughput_1kb_mbps | 3.07 | 3.08 | +0.6% | MB/s |  |
| equal_weight_fairness_jains_index | 1.00 | 1.00 | +0.0% | index |  |
| equal_weight_fairness_max_deviation | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-1 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-2 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-3 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-4 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-5 | 0.00 | 0.00 | n/a | % deviation |  |
| fairness_accuracy_jains_index | 1.00 | 1.00 | +0.0% | index |  |
| fairness_accuracy_max_deviation | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-1 | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-2 | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-3 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-4 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-5 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_overhead_fair_throughput | 1073.89 | 1069.44 | -0.4% | msg/s |  |
| fairness_overhead_fifo_throughput | 1110.16 | 1094.77 | -1.4% | msg/s |  |
| fairness_overhead_pct | 3.27 | 2.74 | -16.1% | % | 🟢 |
| key_cardinality_10_throughput | 1294.20 | 1300.32 | +0.5% | msg/s |  |
| key_cardinality_10k_throughput | 506.02 | 510.47 | +0.9% | msg/s |  |
| key_cardinality_1k_throughput | 789.62 | 786.93 | -0.3% | msg/s |  |
| lua_on_enqueue_overhead_us | 23.41 | 18.67 | -20.2% | us | 🟢 |
| lua_throughput_with_hook | 904.08 | 899.49 | -0.5% | msg/s |  |
| memory_per_message_overhead | 0.00 | 0.00 | n/a | bytes/msg |  |
| memory_rss_idle | 406.79 | 400.40 | -1.6% | MB |  |
| memory_rss_loaded_10k | 305.54 | 304.78 | -0.2% | MB |  |

**Summary:** 0 regressed, 2 improved, 47 unchanged
<!-- bench-results-end -->
