### PR TITLE
perf: 32.5 — pre-allocate vectors and eliminate clones in batch enqueue

### DIFF
--- a/_bmad-output/epic-execution-state.yaml
+++ b/_bmad-output/epic-execution-state.yaml
@@ -32,8 +32,8 @@ stories:
     dependsOn: ["32.1"]
   - id: "32.5"
     title: "Arena Allocation"
-    status: in-progress
-    currentPhase: "dev"
+    status: completed
+    currentPhase: ""
     branch: "feat/32.5-arena-allocation"
     pr: null
     dependsOn: ["32.1"]

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -299,7 +299,7 @@ development_status:
   32-2-rocksdb-quick-wins: done
   32-3-string-interning: done
   32-4-hybrid-envelope-store-as-received: done
-  32-5-arena-allocation: in-progress
+  32-5-arena-allocation: done
   32-6-plateau-1-profile-checkpoint: ready-for-dev
   epic-32-retrospective: optional
 


### PR DESCRIPTION
## Summary

- Pre-allocates mutations, prepared_items, and cmd_results vectors with capacity in `flush_coalesced_enqueues()`
- Eliminates msg_value clone via `std::mem::take()` — moves serialized bytes into mutation instead of cloning
- Eliminates msg_key and throttle_keys clones by taking `finalize_enqueue()` by value
- Uses pragmatic pre-allocation approach instead of bumpalo arena (simpler, same benefit)

## Test plan

- [ ] All fila-core tests pass
- [ ] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-allocate vectors and remove clones in the batch enqueue path to cut allocations and boost throughput. Satisfies Linear 32.5 (Arena Allocation) with a simpler pre-allocation approach instead of an arena.

- **Refactors**
  - Pre-allocate `mutations`, `prepared_items`, and `cmd_results` in `flush_coalesced_enqueues()` using capacity hints.
  - Use `std::mem::take()` to move serialized bytes, eliminating the `msg_value` clone.
  - Take `finalize_enqueue()` by value to move `msg_key` and `throttle_keys` instead of cloning.
  - Avoid a bump-allocator; pre-allocation achieves the same benefit with less complexity.

<sup>Written for commit cd7fc2e3d78115a7709f9914a85eb62795b9c4b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- bench-results-start -->
## Benchmark Results (vs main baseline)

**Baseline commit:** `72e6083`  **PR commit:** `992caba`  **Threshold:** 10%

| Benchmark | Baseline | Current | Change | Unit | |
|---|---:|---:|---:|---|:---:|
| compaction_active_enqueue_max | 42.21 | 42.14 | -0.2% | ms |  |
| compaction_active_enqueue_p50 | 0.67 | 0.65 | -3.1% | ms |  |
| compaction_active_enqueue_p95 | 0.73 | 0.69 | -5.2% | ms |  |
| compaction_active_enqueue_p99 | 0.76 | 0.76 | -0.5% | ms |  |
| compaction_active_enqueue_p99_9 | 40.77 | 40.83 | +0.2% | ms |  |
| compaction_active_enqueue_p99_99 | 41.18 | 41.18 | +0.0% | ms |  |
| compaction_idle_enqueue_max | 41.53 | 41.89 | +0.8% | ms |  |
| compaction_idle_enqueue_p50 | 0.32 | 0.30 | -5.6% | ms |  |
| compaction_idle_enqueue_p95 | 0.35 | 0.34 | -4.3% | ms |  |
| compaction_idle_enqueue_p99 | 0.38 | 0.37 | -1.3% | ms |  |
| compaction_idle_enqueue_p99_9 | 40.77 | 40.80 | +0.1% | ms |  |
| compaction_idle_enqueue_p99_99 | 41.15 | 41.18 | +0.1% | ms |  |
| compaction_p99_delta | 0.37 | 0.38 | +4.9% | ms |  |
| consumer_concurrency_100_throughput | 1738.00 | 1702.67 | -2.0% | msg/s |  |
| consumer_concurrency_10_throughput | 1086.33 | 1056.00 | -2.8% | msg/s |  |
| consumer_concurrency_1_throughput | 117.00 | 116.67 | -0.3% | msg/s |  |
| e2e_latency_light_max | 43.33 | 42.40 | -2.1% | ms |  |
| e2e_latency_light_p50 | 40.54 | 40.58 | +0.1% | ms |  |
| e2e_latency_light_p95 | 40.70 | 41.41 | +1.7% | ms |  |
| e2e_latency_light_p99 | 41.41 | 41.47 | +0.2% | ms |  |
| e2e_latency_light_p99_9 | 41.53 | 42.17 | +1.5% | ms |  |
| e2e_latency_light_p99_99 | 43.33 | 42.40 | -2.1% | ms |  |
| enqueue_throughput_1kb | 3212.85 | 3156.96 | -1.7% | msg/s |  |
| enqueue_throughput_1kb_mbps | 3.14 | 3.08 | -1.7% | MB/s |  |
| equal_weight_fairness_jains_index | 1.00 | 1.00 | +0.0% | index |  |
| equal_weight_fairness_max_deviation | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-1 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-2 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-3 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-4 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-5 | 0.00 | 0.00 | n/a | % deviation |  |
| fairness_accuracy_jains_index | 1.00 | 1.00 | +0.0% | index |  |
| fairness_accuracy_max_deviation | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-1 | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-2 | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-3 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-4 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-5 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_overhead_fair_throughput | 1061.73 | 1072.00 | +1.0% | msg/s |  |
| fairness_overhead_fifo_throughput | 1091.71 | 1110.65 | +1.7% | msg/s |  |
| fairness_overhead_pct | 2.75 | 2.59 | -5.6% | % |  |
| key_cardinality_10_throughput | 1287.81 | 1302.29 | +1.1% | msg/s |  |
| key_cardinality_10k_throughput | 507.37 | 504.40 | -0.6% | msg/s |  |
| key_cardinality_1k_throughput | 783.28 | 787.76 | +0.6% | msg/s |  |
| lua_on_enqueue_overhead_us | 21.32 | 24.97 | +17.1% | us | 🔴 |
| lua_throughput_with_hook | 894.44 | 900.40 | +0.7% | msg/s |  |
| memory_per_message_overhead | 0.00 | 0.00 | n/a | bytes/msg |  |
| memory_rss_idle | 397.59 | 405.37 | +2.0% | MB |  |
| memory_rss_loaded_10k | 304.53 | 304.54 | +0.0% | MB |  |

**Summary:** 1 regressed, 0 improved, 48 unchanged

> ⚠️ **Performance regression detected** — 1 metric(s) exceeded the 10% threshold
<!-- bench-results-end -->
