### PR TITLE
perf: 33.2 — in-memory lease tracking (eliminate per-delivery storage writes)

### DIFF
--- a/_bmad-output/epic-execution-state.yaml
+++ b/_bmad-output/epic-execution-state.yaml
@@ -11,8 +11,8 @@ stories:
     dependsOn: []
   - id: "33.2"
     title: "In-Memory Lease Tracking"
-    status: in-progress
-    currentPhase: "dev"
+    status: completed
+    currentPhase: ""
     branch: "feat/33.2-in-memory-lease-tracking"
     pr: null
     dependsOn: ["33.1"]

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -308,7 +308,7 @@ development_status:
   # Target: 100-200K msg/s end-to-end. Conditional on 32.6 go/no-go.
   epic-33: in-progress
   33-1-in-memory-delivery-queue: done
-  33-2-in-memory-lease-tracking: in-progress
+  33-2-in-memory-lease-tracking: done
   33-3-batch-ack-processing: ready-for-dev
   33-4-plateau-2-profile-checkpoint: ready-for-dev
   epic-33-retrospective: optional


### PR DESCRIPTION
## Summary

- Tracks lease state in `HashMap<Uuid, LeaseInfo>` instead of RocksDB
- Delivery: 0 storage writes (was 2 mutations per message via apply_mutations)
- Ack/Nack: 0 storage reads for lease lookup, 0 lease delete mutations
- Lease expiry reclaim: iterates in-memory map instead of RocksDB range scan
- Graceful shutdown flushes active leases to storage for crash recovery
- Recovery rebuilds in-memory lease state from storage

## Test plan

- [ ] 398 tests pass (2 new lease tracking tests)
- [ ] Clippy clean, fmt clean
- [ ] Lease tracked in memory, not storage, during normal operation
- [ ] Ack removes in-memory lease

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements in-memory lease tracking to remove per-delivery storage I/O, improving throughput and latency while keeping crash recovery intact. Aligns with epic 33, story 33.2.

- **Refactors**
  - Track active leases in a `HashMap<Uuid, LeaseInfo>` instead of RocksDB.
  - Delivery: no storage writes; Ack/Nack: no lease reads or deletes.
  - Lease expiry checks the in-memory map, not a RocksDB range scan.
  - Graceful shutdown flushes leases to storage; startup rebuilds in-memory state from storage.

<sup>Written for commit d3185f54eb95553c8cead1d4f1052832295d4e91. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- bench-results-start -->
## Benchmark Results (vs main baseline)

**Baseline commit:** `7df8e3c`  **PR commit:** `053a893`  **Threshold:** 10%

| Benchmark | Baseline | Current | Change | Unit | |
|---|---:|---:|---:|---|:---:|
| compaction_active_enqueue_max | 41.28 | 41.25 | -0.1% | ms |  |
| compaction_active_enqueue_p50 | 0.65 | 0.65 | +0.3% | ms |  |
| compaction_active_enqueue_p95 | 0.69 | 0.69 | +0.3% | ms |  |
| compaction_active_enqueue_p99 | 0.77 | 0.77 | +0.4% | ms |  |
| compaction_active_enqueue_p99_9 | 40.80 | 40.80 | +0.0% | ms |  |
| compaction_active_enqueue_p99_99 | 41.18 | 41.18 | +0.0% | ms |  |
| compaction_idle_enqueue_max | 42.21 | 41.44 | -1.8% | ms |  |
| compaction_idle_enqueue_p50 | 0.30 | 0.30 | +2.0% | ms |  |
| compaction_idle_enqueue_p95 | 0.33 | 0.34 | +1.5% | ms |  |
| compaction_idle_enqueue_p99 | 0.37 | 0.37 | +0.5% | ms |  |
| compaction_idle_enqueue_p99_9 | 40.83 | 40.80 | -0.1% | ms |  |
| compaction_idle_enqueue_p99_99 | 41.18 | 41.15 | -0.1% | ms |  |
| compaction_p99_delta | 0.42 | 0.40 | -4.3% | ms |  |
| consumer_concurrency_100_throughput | 1723.67 | 1695.67 | -1.6% | msg/s |  |
| consumer_concurrency_10_throughput | 1099.67 | 1084.00 | -1.4% | msg/s |  |
| consumer_concurrency_1_throughput | 94.33 | 117.33 | +24.4% | msg/s | 🟢 |
| e2e_latency_light_max | 42.43 | 41.63 | -1.9% | ms |  |
| e2e_latency_light_p50 | 40.58 | 40.58 | +0.0% | ms |  |
| e2e_latency_light_p95 | 41.41 | 41.41 | +0.0% | ms |  |
| e2e_latency_light_p99 | 41.44 | 41.44 | +0.0% | ms |  |
| e2e_latency_light_p99_9 | 41.63 | 41.50 | -0.3% | ms |  |
| e2e_latency_light_p99_99 | 42.43 | 41.63 | -1.9% | ms |  |
| enqueue_throughput_1kb | 3171.99 | 3191.29 | +0.6% | msg/s |  |
| enqueue_throughput_1kb_mbps | 3.10 | 3.12 | +0.6% | MB/s |  |
| equal_weight_fairness_jains_index | 1.00 | 1.00 | +0.0% | index |  |
| equal_weight_fairness_max_deviation | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-1 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-2 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-3 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-4 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-5 | 0.00 | 0.00 | n/a | % deviation |  |
| fairness_accuracy_jains_index | 1.00 | 1.00 | +0.0% | index |  |
| fairness_accuracy_max_deviation | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-1 | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-2 | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-3 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-4 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-5 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_overhead_fair_throughput | 1082.73 | 1084.57 | +0.2% | msg/s |  |
| fairness_overhead_fifo_throughput | 1119.83 | 1115.84 | -0.4% | msg/s |  |
| fairness_overhead_pct | 3.29 | 2.80 | -14.8% | % | 🟢 |
| key_cardinality_10_throughput | 1297.59 | 1293.23 | -0.3% | msg/s |  |
| key_cardinality_10k_throughput | 511.98 | 506.64 | -1.0% | msg/s |  |
| key_cardinality_1k_throughput | 785.68 | 795.51 | +1.3% | msg/s |  |
| lua_on_enqueue_overhead_us | 24.14 | 21.44 | -11.2% | us | 🟢 |
| lua_throughput_with_hook | 898.91 | 909.39 | +1.2% | msg/s |  |
| memory_per_message_overhead | 0.00 | 0.00 | n/a | bytes/msg |  |
| memory_rss_idle | 401.32 | 409.02 | +1.9% | MB |  |
| memory_rss_loaded_10k | 304.64 | 305.75 | +0.4% | MB |  |

**Summary:** 0 regressed, 3 improved, 46 unchanged
<!-- bench-results-end -->
