### PR TITLE
perf: 33.3 — batch ack delete processing (amortize per-ack storage writes)

### DIFF
--- a/_bmad-output/epic-execution-state.yaml
+++ b/_bmad-output/epic-execution-state.yaml
@@ -18,8 +18,8 @@ stories:
     dependsOn: ["33.1"]
   - id: "33.3"
     title: "Batch Ack/Nack Processing"
-    status: in-progress
-    currentPhase: "dev"
+    status: completed
+    currentPhase: ""
     branch: "feat/33.3-batch-ack"
     pr: null
     dependsOn: ["33.2"]

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -309,7 +309,7 @@ development_status:
   epic-33: in-progress
   33-1-in-memory-delivery-queue: done
   33-2-in-memory-lease-tracking: done
-  33-3-batch-ack-processing: in-progress
+  33-3-batch-ack-processing: done
   33-4-plateau-2-profile-checkpoint: ready-for-dev
   epic-33-retrospective: optional
 


### PR DESCRIPTION
## Summary

- Accumulates ack-triggered DeleteMessage/DeleteLease mutations in a buffer instead of writing per-ack
- Flushes buffer as single WriteBatch on scheduler tick (every loop iteration) and on shutdown
- Configurable threshold for early flush (default: 10,000 pending deletes)
- Double-ack guard via pending_ack_ids HashSet
- Nack NOT batched (requires synchronous message modification for retry/DLQ)

## Test plan

- [ ] 398 tests pass (2 new batch ack tests)
- [ ] Messages remain in storage after ack until flush
- [ ] Early flush triggers at threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batches ack-triggered delete writes to cut per-ack I/O and improve throughput. Implements 33.3 by buffering DeleteMessage/DeleteLease and flushing as a single write batch each scheduler tick and on shutdown.

- **New Features**
  - Buffer ack deletes; flush once per loop and on shutdown.
  - Configurable early flush threshold (default 10,000 pending deletes).
  - Double-ack guard via `pending_ack_ids`.
  - NACK handling stays synchronous (not batched) to preserve retry/DLQ semantics.

<sup>Written for commit eab87b749f4fa0d362869e31753fc68a02afaf04. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- bench-results-start -->
## Benchmark Results (vs main baseline)

**Baseline commit:** `da7da3c`  **PR commit:** `da33ee9`  **Threshold:** 10%

| Benchmark | Baseline | Current | Change | Unit | |
|---|---:|---:|---:|---|:---:|
| compaction_active_enqueue_max | 42.08 | 41.31 | -1.8% | ms |  |
| compaction_active_enqueue_p50 | 0.67 | 0.66 | -1.6% | ms |  |
| compaction_active_enqueue_p95 | 0.71 | 0.75 | +5.2% | ms |  |
| compaction_active_enqueue_p99 | 0.79 | 0.87 | +10.0% | ms | 🔴 |
| compaction_active_enqueue_p99_9 | 40.73 | 40.77 | +0.1% | ms |  |
| compaction_active_enqueue_p99_99 | 41.18 | 41.22 | +0.1% | ms |  |
| compaction_idle_enqueue_max | 41.44 | 41.60 | +0.4% | ms |  |
| compaction_idle_enqueue_p50 | 0.32 | 0.28 | -13.3% | ms | 🟢 |
| compaction_idle_enqueue_p95 | 0.36 | 0.33 | -7.3% | ms |  |
| compaction_idle_enqueue_p99 | 0.39 | 0.39 | -1.0% | ms |  |
| compaction_idle_enqueue_p99_9 | 40.80 | 40.83 | +0.1% | ms |  |
| compaction_idle_enqueue_p99_99 | 41.18 | 41.22 | +0.1% | ms |  |
| compaction_p99_delta | 0.37 | 0.46 | +26.2% | ms | 🔴 |
| consumer_concurrency_100_throughput | 1749.00 | 1670.33 | -4.5% | msg/s |  |
| consumer_concurrency_10_throughput | 1103.67 | 1043.67 | -5.4% | msg/s |  |
| consumer_concurrency_1_throughput | 123.33 | 91.67 | -25.7% | msg/s | 🔴 |
| e2e_latency_light_max | 41.60 | 42.34 | +1.8% | ms |  |
| e2e_latency_light_p50 | 40.54 | 40.61 | +0.2% | ms |  |
| e2e_latency_light_p95 | 41.34 | 41.41 | +0.2% | ms |  |
| e2e_latency_light_p99 | 41.44 | 41.44 | +0.0% | ms |  |
| e2e_latency_light_p99_9 | 41.47 | 41.57 | +0.2% | ms |  |
| e2e_latency_light_p99_99 | 41.60 | 42.34 | +1.8% | ms |  |
| enqueue_throughput_1kb | 3062.98 | 3144.87 | +2.7% | msg/s |  |
| enqueue_throughput_1kb_mbps | 2.99 | 3.07 | +2.7% | MB/s |  |
| equal_weight_fairness_jains_index | 1.00 | 1.00 | +0.0% | index |  |
| equal_weight_fairness_max_deviation | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-1 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-2 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-3 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-4 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-5 | 0.00 | 0.00 | n/a | % deviation |  |
| fairness_accuracy_jains_index | 1.00 | 1.00 | +0.0% | index |  |
| fairness_accuracy_max_deviation | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-1 | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-2 | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-3 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-4 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-5 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_overhead_fair_throughput | 1054.78 | 1073.28 | +1.8% | msg/s |  |
| fairness_overhead_fifo_throughput | 1091.13 | 1104.85 | +1.3% | msg/s |  |
| fairness_overhead_pct | 3.33 | 2.86 | -14.2% | % | 🟢 |
| key_cardinality_10_throughput | 1276.73 | 1282.41 | +0.4% | msg/s |  |
| key_cardinality_10k_throughput | 503.07 | 504.28 | +0.2% | msg/s |  |
| key_cardinality_1k_throughput | 776.43 | 773.43 | -0.4% | msg/s |  |
| lua_on_enqueue_overhead_us | 26.50 | 17.96 | -32.2% | us | 🟢 |
| lua_throughput_with_hook | 882.93 | 899.86 | +1.9% | msg/s |  |
| memory_per_message_overhead | 0.00 | 0.00 | n/a | bytes/msg |  |
| memory_rss_idle | 397.64 | 392.04 | -1.4% | MB |  |
| memory_rss_loaded_10k | 302.44 | 304.04 | +0.5% | MB |  |

**Summary:** 3 regressed, 3 improved, 43 unchanged

> ⚠️ **Performance regression detected** — 3 metric(s) exceeded the 10% threshold
<!-- bench-results-end -->
