### PR TITLE
perf: 34.1 — enable titan blob separation for cf_messages

### DIFF
--- a/_bmad-output/epic-execution-state.yaml
+++ b/_bmad-output/epic-execution-state.yaml
@@ -4,9 +4,9 @@ startedAt: "2026-03-25T00:00:00Z"
 stories:
   - id: "34.1"
     title: "Titan Blob Separation"
-    status: pending
+    status: completed
     currentPhase: ""
-    branch: ""
+    branch: "feat/34.1-titan-blob-separation"
     pr: null
     dependsOn: []
   - id: "34.2"

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -317,7 +317,7 @@ development_status:
   # Titan blob separation, custom append-only log, multi-shard, H-DRR.
   # Target: 200-400K+ msg/s. Conditional on 33.4 go/no-go. Stories 34.2/34.3 conditional on 34.1.
   epic-34: in-progress
-  34-1-titan-blob-separation: in-progress
+  34-1-titan-blob-separation: done
   34-2-append-only-log-prototype: ready-for-dev
   34-3-tee-engine-validation: ready-for-dev
   34-4-multi-shard-default: ready-for-dev


### PR DESCRIPTION
## Summary

- Enables RocksDB BlobDB (Titan-style) for CF_MESSAGES column family
- Values >= 1KB stored in blob files instead of SST files, reducing write amplification
- Configurable: enable_blob_files, min_blob_size, blob_file_size, enable_blob_gc, blob_gc_age_cutoff
- Enabled by default with sensible defaults (1KB threshold, 256MB blob files, GC at 25%)

## Test plan

- [ ] All fila-core tests pass
- [ ] Config defaults and TOML parsing tests updated
- [ ] Blob separation can be disabled via config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Titan-style blob separation for the `CF_MESSAGES` column family to reduce write amplification and improve sustained write throughput. Completes Linear 34.1: Titan Blob Separation.

- **New Features**
  - Values ≥ 1KB are stored in blob files instead of SSTs.
  - Config flags: `enable_blob_files`, `min_blob_size`, `blob_file_size`, `enable_blob_gc`, `blob_gc_age_cutoff`.
  - Defaults: enabled, 1KB threshold, 256MB blob files, GC at 25%. Can be disabled via config.

<sup>Written for commit 08202849f7bb1d90375281dc6923401dbfcf579f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- bench-results-start -->
## Benchmark Results (vs main baseline)

**Baseline commit:** `26f2252`  **PR commit:** `ecb4586`  **Threshold:** 10%

| Benchmark | Baseline | Current | Change | Unit | |
|---|---:|---:|---:|---|:---:|
| compaction_active_enqueue_max | 41.25 | 41.28 | +0.1% | ms |  |
| compaction_active_enqueue_p50 | 0.66 | 0.64 | -2.0% | ms |  |
| compaction_active_enqueue_p95 | 0.70 | 0.69 | -1.7% | ms |  |
| compaction_active_enqueue_p99 | 0.77 | 0.78 | +0.8% | ms |  |
| compaction_active_enqueue_p99_9 | 40.77 | 40.77 | +0.0% | ms |  |
| compaction_active_enqueue_p99_99 | 41.22 | 41.22 | +0.0% | ms |  |
| compaction_idle_enqueue_max | 41.50 | 41.70 | +0.5% | ms |  |
| compaction_idle_enqueue_p50 | 0.31 | 0.29 | -4.2% | ms |  |
| compaction_idle_enqueue_p95 | 0.35 | 0.34 | -3.2% | ms |  |
| compaction_idle_enqueue_p99 | 0.39 | 0.37 | -3.6% | ms |  |
| compaction_idle_enqueue_p99_9 | 40.83 | 40.86 | +0.1% | ms |  |
| compaction_idle_enqueue_p99_99 | 41.18 | 41.22 | +0.1% | ms |  |
| compaction_p99_delta | 0.38 | 0.40 | +5.3% | ms |  |
| consumer_concurrency_100_throughput | 1738.33 | 1601.00 | -7.9% | msg/s |  |
| consumer_concurrency_10_throughput | 1070.00 | 824.00 | -23.0% | msg/s | 🔴 |
| consumer_concurrency_1_throughput | 102.67 | 99.33 | -3.2% | msg/s |  |
| e2e_latency_light_max | 42.34 | 42.49 | +0.4% | ms |  |
| e2e_latency_light_p50 | 40.61 | 41.28 | +1.7% | ms |  |
| e2e_latency_light_p95 | 41.41 | 41.41 | +0.0% | ms |  |
| e2e_latency_light_p99 | 41.47 | 41.47 | +0.0% | ms |  |
| e2e_latency_light_p99_9 | 41.57 | 41.70 | +0.3% | ms |  |
| e2e_latency_light_p99_99 | 42.34 | 42.49 | +0.4% | ms |  |
| enqueue_throughput_1kb | 3179.93 | 3126.75 | -1.7% | msg/s |  |
| enqueue_throughput_1kb_mbps | 3.11 | 3.05 | -1.7% | MB/s |  |
| equal_weight_fairness_jains_index | 1.00 | 1.00 | +0.0% | index |  |
| equal_weight_fairness_max_deviation | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-1 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-2 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-3 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-4 | 0.00 | 0.00 | n/a | % deviation |  |
| equal_weight_fairness_tenant-5 | 0.00 | 0.00 | n/a | % deviation |  |
| fairness_accuracy_jains_index | 1.00 | 1.00 | +0.0% | index |  |
| fairness_accuracy_max_deviation | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-1 | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-2 | 0.20 | 0.20 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-3 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-4 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_accuracy_tenant-5 | 0.10 | 0.10 | +0.0% | % deviation |  |
| fairness_overhead_fair_throughput | 1066.97 | 1040.10 | -2.5% | msg/s |  |
| fairness_overhead_fifo_throughput | 1106.99 | 1078.70 | -2.6% | msg/s |  |
| fairness_overhead_pct | 3.74 | 3.23 | -13.5% | % | 🟢 |
| key_cardinality_10_throughput | 1298.17 | 1300.54 | +0.2% | msg/s |  |
| key_cardinality_10k_throughput | 507.05 | 506.16 | -0.2% | msg/s |  |
| key_cardinality_1k_throughput | 778.62 | 788.51 | +1.3% | msg/s |  |
| lua_on_enqueue_overhead_us | 19.08 | 23.37 | +22.5% | us | 🔴 |
| lua_throughput_with_hook | 898.00 | 895.49 | -0.3% | msg/s |  |
| memory_per_message_overhead | 0.00 | 0.00 | n/a | bytes/msg |  |
| memory_rss_idle | 406.50 | 397.32 | -2.3% | MB |  |
| memory_rss_loaded_10k | 303.70 | 305.73 | +0.7% | MB |  |

**Summary:** 2 regressed, 1 improved, 46 unchanged

> ⚠️ **Performance regression detected** — 2 metric(s) exceeded the 10% threshold
<!-- bench-results-end -->
