### PR TITLE
fix: use bare tcp address for fibp in competitive bench

### DIFF
--- a/bench/competitive/fila.toml
+++ b/bench/competitive/fila.toml
@@ -1,3 +1,3 @@
 # Fila server config for competitive benchmarks (Docker container).
-[server]
+[fibp]
 listen_addr = "0.0.0.0:5555"

--- a/crates/fila-bench/src/bin/bench-competitive.rs
+++ b/crates/fila-bench/src/bin/bench-competitive.rs
@@ -1039,7 +1039,10 @@ mod fila {
     use fila_sdk::{AccumulatorMode, ConnectOptions, FilaClient};
     use tokio_stream::StreamExt;
 
-    const ADDR: &str = "http://localhost:5555";
+    // Bare host:port — passed directly to FibpTransport::connect which expects a
+    // raw TCP address. FilaClient::connect also accepts this form (it only strips
+    // an "http://" prefix when present; no prefix → connects via TCP directly).
+    const ADDR: &str = "localhost:5555";
     /// Number of concurrent producers for throughput scenarios.
     /// Concurrent producers are needed to trigger auto-batching: the Nagle-style
     /// batcher sends immediately when idle, so a single serial producer never


### PR DESCRIPTION
## Summary

- `FibpTransport::connect` expects a raw `host:port` TCP address, not a URL. The `fila` module in `bench-competitive.rs` had `const ADDR: &str = "http://localhost:5555"`, which was passed unchanged to `create_queue_cli` → `FibpTransport::connect`, causing a DNS resolution failure (Go tried to look up `"http"` as a hostname).
- `FilaClient::connect` strips `http://` before connecting, so SDK calls worked fine — only the `create_queue_cli` path (which calls `FibpTransport::connect` directly) was broken.
- Also fixes `bench/competitive/fila.toml` to use the correct `[fibp]` config section instead of the legacy `[server]` section (which is silently ignored post-FIBP migration).

## Test plan

- [ ] CI competitive bench workflow passes (was failing with `InvalidArgument("FIBP connect failed: failed to lookup address information: Name or service not known")`)
- [ ] Verify Cubic has no findings before marking done

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the competitive bench FIBP connection by using a bare TCP address and the correct config section. Prevents DNS errors and unblocks the CI competitive bench.

- Bug Fixes
  - Use "localhost:5555" instead of "http://localhost:5555" to match Fibp transport expectations.
  - Switch `bench/competitive/fila.toml` from `[server]` to `[fibp]`.

<sup>Written for commit 4677f651621a7f7ef765b2f003ea525345d70ee5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

