### PR TITLE
chore: remove temporary feature branch from bench-regression push trigger

### DIFF
--- a/.github/workflows/bench-regression.yml
+++ b/.github/workflows/bench-regression.yml
@@ -3,7 +3,7 @@ name: Bench Regression
 on:
   pull_request:
   push:
-    branches: [main, fix/bench-regression-ghpages]
+    branches: [main]
   workflow_dispatch:
     inputs:
       update_baseline:


### PR DESCRIPTION
## Summary

- The `fix/bench-regression-ghpages` branch was temporarily added to the push trigger in PR #141 to verify the workflow runs
- That PR is now merged; removing the stale branch reference from the trigger

## Test plan

- [ ] No functional change — just cleanup of the temporary branch reference

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the temporary `fix/bench-regression-ghpages` branch from the bench-regression workflow push trigger so it only runs on `main`. This cleans up the verification change and avoids unnecessary workflow runs.

<sup>Written for commit f9fa310499f1f6bb7bf9bf0924e3cf7b37865140. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

