### PR TITLE
ci: add timeouts to e2e and competitive bench workflows

### DIFF
--- a/.github/workflows/bench-competitive.yml
+++ b/.github/workflows/bench-competitive.yml
@@ -13,6 +13,7 @@ jobs:
   competitive-bench:
     name: Competitive Bench
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,6 +12,7 @@ jobs:
   e2e:
     name: End-to-End Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@stable
@@ -22,4 +23,4 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: taiki-e/install-action@34ac9396e2ddcdd0baa9d56f88b84e09f95c0c77 # cargo-nextest
       - run: cargo build --workspace
-      - run: cargo nextest run -p fila-e2e
+      - run: cargo nextest run -p fila-e2e --test-threads 1 --slow-timeout 60s --fail-fast


### PR DESCRIPTION
## Summary

- E2E: 20min job timeout + 60s per-test slow-timeout via nextest + `--fail-fast`
- Competitive Bench: 45min job timeout
- Prevents hung CI runs from blocking the pipeline (E2E was stuck for 87+ min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add job timeouts and stricter test settings to E2E and competitive bench workflows to stop hung CI runs. Prevents long-running jobs from blocking the pipeline (E2E previously stuck for 87+ min).

- **Bug Fixes**
  - E2E: 20-min job timeout; runs `cargo nextest run -p fila-e2e --test-threads 1 --slow-timeout 60s --fail-fast`.
  - Competitive Bench: 45-min job timeout.

<sup>Written for commit a31cb814613654247f201756601bac6a6b3efd91. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

