### PR TITLE
ci: fix nextest args in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,4 +23,4 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: taiki-e/install-action@34ac9396e2ddcdd0baa9d56f88b84e09f95c0c77 # cargo-nextest
       - run: cargo build --workspace
-      - run: cargo nextest run -p fila-e2e --test-threads 1 --slow-timeout 60s --fail-fast
+      - run: cargo nextest run -p fila-e2e --test-threads 1 --fail-fast


### PR DESCRIPTION
Remove unsupported --slow-timeout flag from nextest command. The 20min job timeout is sufficient.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unsupported `--slow-timeout` flag from `cargo nextest` in the e2e workflow to prevent argument errors; the 20-minute job timeout is sufficient.

<sup>Written for commit bfe431217e3fa02be3221efd2b26ca29d526662e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

